### PR TITLE
add -lm flag to openjpeg LDFLAGS

### DIFF
--- a/openjpeg/j2kcodec_linux_amd64.go
+++ b/openjpeg/j2kcodec_linux_amd64.go
@@ -1,7 +1,7 @@
 package openjpeg
 
 // #cgo CFLAGS: -I j2klib/include -I j2klib/linux_amd64
-// #cgo LDFLAGS: -L j2klib/linux_amd64 -lopenjpeg
+// #cgo LDFLAGS: -L j2klib/linux_amd64 -lopenjpeg -lm
 // #include "j2klib/decomj2k.c"
 // #include "j2klib/comj2k.c"
 import "C"


### PR DESCRIPTION
On nixos I had to add the `-lm` LDFLAG to build the openjpeg package. Unsure if this will lead to problems on other OS and whether we should do the dame to other platforms.