### PR TITLE
Harden DICOM network input against malformed/hostile peers

### DIFF
--- a/network/p_data_tf.go
+++ b/network/p_data_tf.go
@@ -48,6 +48,15 @@ func (pd *PresentationDataTransfer) ReadDynamic(buf *media.DICOMBuffer) (err err
 			return err
 		}
 
+		// Guard against malformed PDV lengths before any uint32 arithmetic.
+		// pdv.Length counts the 2 header bytes (PCID + MsgHeader) plus payload,
+		// so it must be at least 2. It must also fit within the bytes the
+		// enclosing PDU claimed to carry (count), otherwise the subtractions
+		// below would underflow and spin this loop on a huge wrapped value.
+		if pd.pdv.Length < 2 || uint64(pd.pdv.Length)+4 > uint64(count) {
+			return fmt.Errorf("pdata: malformed PDV length %d (remaining %d)", pd.pdv.Length, count)
+		}
+
 		// ReadSlice returns a zero-copy view into buf's backing array —
 		// buf is freshly allocated per PDU and never reused, so the slice
 		// is stable for the lifetime of this call.

--- a/network/pdu_input_hardening_test.go
+++ b/network/pdu_input_hardening_test.go
@@ -1,0 +1,113 @@
+package network
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/media"
+)
+
+// pduWithReader builds a pduService whose read side is fed from the given bytes.
+func pduWithReader(data []byte) *pduService {
+	pdu := NewPDUService().(*pduService)
+	r := bufio.NewReader(bytes.NewReader(data))
+	w := bufio.NewWriter(&bytes.Buffer{})
+	pdu.SetConn(bufio.NewReadWriter(r, w))
+	return pdu
+}
+
+// pduHeader encodes a 10-byte PDU header with the given item type and length.
+func pduHeader(itemType byte, pduLength uint32) []byte {
+	return []byte{
+		itemType, 0x00,
+		byte(pduLength >> 24), byte(pduLength >> 16), byte(pduLength >> 8), byte(pduLength),
+		0, 0, 0, 0,
+	}
+}
+
+func TestReadIncomingPDURejectsOversizedLength(t *testing.T) {
+	// A hostile peer advertises a PDU length near 4 GiB. readIncomingPDU must
+	// reject it before allocating, rather than attempting a multi-GiB make().
+	header := pduHeader(0x04, maxIncomingPDULength+1)
+	pdu := pduWithReader(header)
+
+	_, _, err := pdu.readIncomingPDU()
+	if err == nil {
+		t.Fatal("expected error for oversized PDU length, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Fatalf("expected 'exceeds maximum' error, got %v", err)
+	}
+}
+
+func TestReadIncomingPDURejectsTruncatedLength(t *testing.T) {
+	header := pduHeader(0x04, 3) // below the 4-byte minimum
+	pdu := pduWithReader(header)
+
+	_, _, err := pdu.readIncomingPDU()
+	if err == nil {
+		t.Fatal("expected error for PDU length below minimum, got nil")
+	}
+	if !strings.Contains(err.Error(), "minimum") {
+		t.Fatalf("expected 'minimum' error, got %v", err)
+	}
+}
+
+func TestReadIncomingPDUAcceptsLengthAtCeiling(t *testing.T) {
+	// A PDU whose declared length is exactly the ceiling is allowed; the read
+	// then fails on EOF because no payload follows, proving the cap itself did
+	// not reject it.
+	header := pduHeader(0x04, maxIncomingPDULength)
+	pdu := pduWithReader(header)
+
+	_, _, err := pdu.readIncomingPDU()
+	if err != nil && strings.Contains(err.Error(), "exceeds maximum") {
+		t.Fatalf("length at ceiling must not be rejected by the cap, got %v", err)
+	}
+}
+
+func TestReadDynamicRejectsUnderflowingPDVLength(t *testing.T) {
+	// Craft a P-DATA-TF body whose PDV length is larger than the bytes the PDU
+	// claims to carry. Without the guard, the uint32 subtractions in ReadDynamic
+	// underflow and spin the loop on a huge wrapped count.
+	var body bytes.Buffer
+	body.WriteByte(0x00) // Reserved1
+	// PDU data length = 10 bytes follow for the PDV section.
+	body.Write([]byte{0x00, 0x00, 0x00, 0x0A})
+	// pdv.Length = 0xFFFFFFFF (claims ~4 GiB, far beyond the 10 declared).
+	body.Write([]byte{0xFF, 0xFF, 0xFF, 0xFF})
+	body.WriteByte(0x01) // PresentationContextID
+	body.WriteByte(0x02) // MsgHeader (not last fragment)
+
+	buf := media.NewDICOMBufferFromBytes(body.Bytes())
+	buf.SetBigEndian(true)
+
+	pd := &PresentationDataTransfer{Buffer: media.NewDICOMBuffer()}
+	err := pd.ReadDynamic(buf)
+	if err == nil {
+		t.Fatal("expected error for malformed PDV length, got nil")
+	}
+	if !strings.Contains(err.Error(), "malformed PDV length") {
+		t.Fatalf("expected 'malformed PDV length' error, got %v", err)
+	}
+}
+
+func TestReadDynamicRejectsTooSmallPDVLength(t *testing.T) {
+	// pdv.Length must be at least 2 (the PCID + MsgHeader bytes it counts).
+	var body bytes.Buffer
+	body.WriteByte(0x00)                       // Reserved1
+	body.Write([]byte{0x00, 0x00, 0x00, 0x06}) // PDU data length
+	body.Write([]byte{0x00, 0x00, 0x00, 0x01}) // pdv.Length = 1 (illegal)
+	body.WriteByte(0x01)                       // PCID
+	body.WriteByte(0x02)                       // MsgHeader
+
+	buf := media.NewDICOMBufferFromBytes(body.Bytes())
+	buf.SetBigEndian(true)
+
+	pd := &PresentationDataTransfer{Buffer: media.NewDICOMBuffer()}
+	if err := pd.ReadDynamic(buf); err == nil {
+		t.Fatal("expected error for PDV length below 2, got nil")
+	}
+}

--- a/network/pdu_service.go
+++ b/network/pdu_service.go
@@ -132,6 +132,15 @@ func NewPDUService(opts ...PDUServiceOption) PDUService {
 
 const maxPduLength uint32 = 16384
 
+// maxIncomingPDULength is an absolute ceiling on the byte length of any PDU we
+// will read off the wire, enforced before allocating the receive buffer. It is
+// deliberately far larger than the negotiated P-DATA-TF maximum (maxPduLength)
+// so legitimate association PDUs carrying many presentation contexts still fit,
+// while a hostile or buggy peer advertising a near-4 GiB PDU length cannot force
+// a multi-gigabyte allocation (DoS). 16 MiB is orders of magnitude above any
+// conformant PDU yet trivially bounded.
+const maxIncomingPDULength uint32 = 16 << 20
+
 const releaseHandshakeTimeout = 5 * time.Second
 
 // resolveImplClass returns the implementation class UID and version to use
@@ -593,6 +602,9 @@ func (pdu *pduService) readIncomingPDU() (byte, []byte, error) {
 	}
 	if pduLength < 4 {
 		return 0, nil, fmt.Errorf("pdu: malformed PDU length %d (minimum is 4)", pduLength)
+	}
+	if pduLength > maxIncomingPDULength {
+		return 0, nil, fmt.Errorf("pdu: PDU length %d exceeds maximum %d", pduLength, maxIncomingPDULength)
 	}
 
 	remaining := int(pduLength) - 4

--- a/services/scp.go
+++ b/services/scp.go
@@ -119,12 +119,13 @@ type scp struct {
 	onRawPDU             func(event network.RawPDUEvent)
 	canceledMessageIDs   map[uint16]struct{}
 
-	bufSize      int
-	cancelPoll   time.Duration
-	cancelGrace  time.Duration
-	implClassUID string
-	implVersion  string
-	timeout      int
+	bufSize         int
+	cancelPoll      time.Duration
+	cancelGrace     time.Duration
+	implClassUID    string
+	implVersion     string
+	timeout         int
+	maxAssociations int
 }
 
 // SCPOption configures an SCP at construction time.
@@ -160,6 +161,17 @@ func WithCancelGraceWindow(d time.Duration) SCPOption {
 		if d > 0 {
 			s.cancelGrace = d
 		}
+	}
+}
+
+// WithMaxAssociations bounds the number of associations the SCP will service
+// concurrently. Connections accepted beyond the limit block in the accept loop
+// (applying TCP backpressure) until an in-flight association completes, rather
+// than spawning an unbounded number of goroutines under a connection flood.
+// A value <= 0 (the default) means unlimited.
+func WithMaxAssociations(n int) SCPOption {
+	return func(s *scp) {
+		s.maxAssociations = n
 	}
 }
 

--- a/services/scp_maxassoc_test.go
+++ b/services/scp_maxassoc_test.go
@@ -1,0 +1,68 @@
+package services
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/innovative-io/io-dicom/network"
+)
+
+// TestSCP_WithMaxAssociations verifies that the accept loop never runs more
+// association handlers concurrently than the configured limit. Each handler
+// holds its slot for a short, fixed window while a peak-concurrency counter is
+// observed; with a limit of 1 the peak must never exceed 1 even though several
+// SCUs connect at once.
+func TestSCP_WithMaxAssociations(t *testing.T) {
+	const port = 1101
+	_, testSCP := StartSCP(t, port, WithMaxAssociations(1))
+
+	testSCP.OnAssociationRequest(func(request network.AssociationRequest) bool {
+		return true
+	})
+
+	var current atomic.Int32
+	var peak atomic.Int32
+	testSCP.OnCEchoRequest(func(request network.AssociationRequest) bool {
+		n := current.Add(1)
+		// Record the high-water mark of concurrent handlers.
+		for {
+			p := peak.Load()
+			if n <= p || peak.CompareAndSwap(p, n) {
+				break
+			}
+		}
+		// Hold the association slot long enough that any unbounded concurrency
+		// would overlap here.
+		time.Sleep(80 * time.Millisecond)
+		current.Add(-1)
+		return true
+	})
+
+	const clients = 4
+	var wg sync.WaitGroup
+	for i := 0; i < clients; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			dest := &network.Destination{
+				Name:      "MaxAssocTest",
+				CalledAE:  "SCP",
+				CallingAE: "SCU",
+				HostName:  "localhost",
+				Port:      port,
+			}
+			scu := NewSCU(dest)
+			if err := scu.EchoSCU(context.Background()); err != nil {
+				t.Errorf("EchoSCU: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := peak.Load(); got > 1 {
+		t.Fatalf("peak concurrent associations = %d, want <= 1", got)
+	}
+}

--- a/services/scp_server.go
+++ b/services/scp_server.go
@@ -39,9 +39,29 @@ func (s *scp) Start(ctx context.Context) error {
 		s.listener.Close()
 	}()
 
+	// When a concurrency limit is configured, sem is a counting semaphore that
+	// caps the number of in-flight association goroutines. Acquiring before
+	// Accept returns the next connection applies TCP backpressure on a flood
+	// instead of spawning unbounded goroutines. A nil sem means unlimited.
+	var sem chan struct{}
+	if s.maxAssociations > 0 {
+		sem = make(chan struct{}, s.maxAssociations)
+	}
+
 	for {
+		if sem != nil {
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return nil
+			}
+		}
+
 		conn, err := s.listener.Accept()
 		if err != nil {
+			if sem != nil {
+				<-sem
+			}
 			if errors.Is(err, net.ErrClosed) {
 				return nil
 			}
@@ -52,6 +72,9 @@ func (s *scp) Start(ctx context.Context) error {
 		s.wg.Add(1)
 		go func(c net.Conn) {
 			defer s.wg.Done()
+			if sem != nil {
+				defer func() { <-sem }()
+			}
 			s.handleConnection(ctx, c)
 		}(conn)
 	}


### PR DESCRIPTION
## Summary

Three correctness/DoS fixes in the network and services layers, each with regression coverage. All target robustness against a non-conformant or hostile DICOM peer.

## What changed

### 1. Bounded PDU read allocation — `network/pdu_service.go`
`readIncomingPDU` read a 32-bit `pduLength` straight off the wire and did `make([]byte, 10+remaining)` with no upper bound — a peer advertising a near-4 GiB PDU length could force a multi-gigabyte allocation per connection (trivial OOM/DoS). Added a 16 MiB ceiling (`maxIncomingPDULength`) enforced *before* the allocation. The cap is far above any conformant PDU yet bounds the worst case.

### 2. PDV length underflow guard — `network/p_data_tf.go`
`ReadDynamic` performed `uint32` subtractions (`pdv.Length - 2`, `count - pdv.Length - 4`) without validating `pdv.Length`. A malformed value (< 2, or larger than the bytes the PDU claims to carry) wrapped these into huge values, spinning the loop. Added a bounds check using `uint64` widening so the `+4` itself can't overflow.

### 3. Concurrent-association limit — `services/scp.go`, `services/scp_server.go`
The accept loop spawned one unbounded goroutine per connection — a connection flood meant unbounded goroutines/memory. Added a `WithMaxAssociations(n)` option backed by a counting semaphore acquired before `Accept`, so excess connections block in the accept loop (TCP backpressure) instead of spawning goroutines. **Default (0) is unlimited — fully backward compatible.**

## Why

These were the input paths most likely to crash or hang the library against a buggy/malicious peer. None changes behavior for conformant traffic.

## Tests

New regression tests:
- `network/pdu_input_hardening_test.go` — oversized PDU rejection, sub-minimum length, length exactly at ceiling (not rejected by the cap), PDV underflow, too-small PDV length.
- `services/scp_maxassoc_test.go` — 4 concurrent SCUs against a limit of 1; asserts peak concurrency never exceeds 1 (serialized runtime confirms enforcement).

## Verification

- `go vet ./network/... ./services/...` — clean
- `staticcheck` — no new findings
- `go test -race ./network/ ./services/` — pass, no data races
- Full `media` / `dimse` / `network/...` / `services` suite — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)