### PR TITLE
Structured logging: inject loggers, correlate associations, quiet output

### DIFF
--- a/cmd/io-dicom/main.go
+++ b/cmd/io-dicom/main.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"log/slog"
 	"net"
 	"os"
@@ -26,8 +25,16 @@ import (
 
 var version string
 
+// fatal logs msg at error level with the given structured attributes and exits
+// the process with a non-zero status. It replaces log.Fatal* so the CLI emits
+// the same structured slog output as the rest of the library.
+func fatal(msg string, args ...any) {
+	slog.Error(msg, args...)
+	os.Exit(1)
+}
+
 func main() {
-	log.Printf("Starting io-dicom %s\n\n", version)
+	slog.Info("starting io-dicom", "version", version)
 
 	hostName := flag.String("host", "localhost", "Destination host name or IP")
 	calledAE := flag.String("calledae", "DICOM_SCP", "AE of the destination")
@@ -69,27 +76,27 @@ func main() {
 
 	if *startSCP {
 		if *datastore == "" {
-			log.Fatalln("datastore is required for scp")
+			fatal("datastore is required for scp")
 		}
 
 		if *calledAE == "" {
-			log.Fatalln("calledae is required for scp")
+			fatal("calledae is required for scp")
 		}
 
 		var scp services.SCP
 		if *tlsEnabled {
 			if *tlsCert == "" || *tlsKey == "" {
-				log.Fatalln("-tlscert and -tlskey are required when -scp -tls is set")
+				fatal("-tlscert and -tlskey are required when -scp -tls is set")
 			}
 			cert, err := tls.LoadX509KeyPair(*tlsCert, *tlsKey)
 			if err != nil {
-				log.Fatalf("failed to load TLS certificate: %v", err)
+				fatal("failed to load TLS certificate", "error", err)
 			}
 			tlsCfg := &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
 			if *tlsCA != "" {
 				pool, err := loadCertPool(*tlsCA)
 				if err != nil {
-					log.Fatalf("failed to load CA certificate: %v", err)
+					fatal("failed to load CA certificate", "error", err)
 				}
 				tlsCfg.ClientCAs = pool
 				tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
@@ -118,7 +125,7 @@ func main() {
 		})
 
 		scp.OnCStoreRequest(func(ctx context.Context, request network.AssociationRequest, data media.DICOMObject) uint16 {
-			log.Printf("INFO, C-Store received %s", data.GetString(tags.SOPInstanceUID))
+			slog.Info("C-Store received", "sop_instance_uid", data.GetString(tags.SOPInstanceUID))
 			directory := filepath.Join(*datastore, data.GetString(tags.PatientID), data.GetString(tags.StudyInstanceUID), data.GetString(tags.SeriesInstanceUID))
 			os.MkdirAll(directory, 0755)
 
@@ -126,7 +133,7 @@ func main() {
 
 			err := data.WriteToFile(path)
 			if err != nil {
-				log.Printf("ERROR: There was an error saving %s : %s", path, err.Error())
+				slog.Error("failed to save instance", "path", path, "error", err)
 			}
 			return dicomstatus.Success
 		})
@@ -140,13 +147,13 @@ func main() {
 			var healthErr error
 			healthListener, healthErr = startTCPHealthListener(ctx, *healthPort, &wg)
 			if healthErr != nil {
-				log.Fatalf("failed to start TCP health listener on port %d: %v", *healthPort, healthErr)
+				fatal("failed to start TCP health listener", "port", *healthPort, "error", healthErr)
 			}
 			defer healthListener.Close()
 		}
 
 		if err := scp.Start(ctx); err != nil {
-			log.Fatal(err)
+			fatal("scp failed", "error", err)
 		}
 		wg.Wait()
 		return
@@ -168,14 +175,14 @@ func main() {
 		if *tlsCA != "" {
 			pool, err := loadCertPool(*tlsCA)
 			if err != nil {
-				log.Fatalf("failed to load CA certificate: %v", err)
+				fatal("failed to load CA certificate", "error", err)
 			}
 			tlsCfg.RootCAs = pool
 		}
 		if *tlsCert != "" && *tlsKey != "" {
 			cert, err := tls.LoadX509KeyPair(*tlsCert, *tlsKey)
 			if err != nil {
-				log.Fatalf("failed to load client TLS certificate: %v", err)
+				fatal("failed to load client TLS certificate", "error", err)
 			}
 			tlsCfg.Certificates = []tls.Certificate{cert}
 		}
@@ -187,25 +194,24 @@ func main() {
 		scu := services.NewSCU(destination)
 		err := scu.EchoSCU(context.Background())
 		if err != nil {
-			log.Fatalln(err)
+			fatal("C-Echo failed", "error", err)
 		}
-		slog.Info("CEcho was successful")
+		slog.Info("C-Echo successful")
 	}
 	if *cfind {
 		request := dimse.DefaultCFindRequest()
 		scu := services.NewSCU(destination)
 		scu.SetOnCFindResult(func(result media.DICOMObject) {
-			log.Printf("Found study %s\n", result.GetString(tags.StudyInstanceUID))
+			slog.Info("found study", "study_instance_uid", result.GetString(tags.StudyInstanceUID))
 			result.DumpTags(os.Stdout)
 		})
 
 		count, status, err := scu.FindSCU(context.Background(), request)
 		if err != nil {
-			log.Fatalln(err)
+			fatal("C-Find failed", "error", err)
 		}
 
-		log.Println("CFind was successful")
-		log.Printf("Found %d results with status %d\n\n", count, status)
+		slog.Info("C-Find successful", "results", count, "status", status)
 		return
 	}
 	if *cmwl {
@@ -217,26 +223,25 @@ func main() {
 		request.Write(tags.RequestedProcedureID, "")
 		scu := services.NewSCU(destination)
 		scu.SetOnCFindResult(func(result media.DICOMObject) {
-			log.Printf("Worklist item: patient=%s accession=%s\n",
-				result.GetString(tags.PatientID), result.GetString(tags.AccessionNumber))
+			slog.Info("worklist item",
+				"patient_id", result.GetString(tags.PatientID), "accession_number", result.GetString(tags.AccessionNumber))
 			result.DumpTags(os.Stdout)
 		})
 
 		count, status, err := scu.WorklistSCU(context.Background(), request)
 		if err != nil {
-			log.Fatalln(err)
+			fatal("MWL query failed", "error", err)
 		}
 
-		log.Println("MWL query was successful")
-		log.Printf("Found %d worklist items with status %d\n\n", count, status)
+		slog.Info("MWL query successful", "items", count, "status", status)
 		return
 	}
 	if *cmove {
 		if *destinationAE == "" {
-			log.Fatalln("destinationae is required for a C-Move")
+			fatal("destinationae is required for a C-Move")
 		}
 		if *studyUID == "" {
-			log.Fatalln("studyuid is required for a C-Move")
+			fatal("studyuid is required for a C-Move")
 		}
 
 		request := dimse.DefaultCMoveRequest(*studyUID)
@@ -244,30 +249,30 @@ func main() {
 		scu := services.NewSCU(destination)
 		_, err := scu.MoveSCU(context.Background(), *destinationAE, request)
 		if err != nil {
-			log.Fatalln(err)
+			fatal("C-Move failed", "error", err)
 		}
-		log.Println("CMove was successful")
+		slog.Info("C-Move successful")
 		return
 	}
 	if *cstore {
 		if *fileName == "" {
-			log.Fatalln("file is required for a C-Store")
+			fatal("file is required for a C-Store")
 		}
 		scu := services.NewSCU(destination)
 		err := scu.StoreSCU(context.Background(), *fileName)
 		if err != nil {
-			log.Fatalln(err)
+			fatal("C-Store failed", "error", err)
 		}
-		log.Printf("CStore of %s was successful", *fileName)
+		slog.Info("C-Store successful", "file", *fileName)
 		return
 	}
 	if *dump {
 		if *fileName == "" {
-			log.Fatalln("file is required for a dump")
+			fatal("file is required for a dump")
 		}
 		obj, err := media.NewDCMObjFromFile(*fileName)
 		if err != nil {
-			log.Fatal(err)
+			fatal("failed to read DICOM file", "error", err)
 		}
 		obj.DumpTags(os.Stdout)
 		return
@@ -294,19 +299,19 @@ func startTCPHealthListener(ctx context.Context, port int, wg *sync.WaitGroup) (
 		return nil, err
 	}
 
-	log.Printf("INFO: TCP health listener started on port %d", port)
+	slog.Info("TCP health listener started", "port", port)
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		defer log.Printf("INFO: TCP health listener stopped on port %d", port)
+		defer slog.Info("TCP health listener stopped", "port", port)
 		for {
 			conn, err := listener.Accept()
 			if err != nil {
 				if errors.Is(err, net.ErrClosed) || ctx.Err() != nil {
 					return
 				}
-				log.Printf("WARN: TCP health listener accept failed on port %d: %v", port, err)
+				slog.Warn("TCP health listener accept failed", "port", port, "error", err)
 				continue
 			}
 			_ = conn.Close()

--- a/dimse/dimse_test.go
+++ b/dimse/dimse_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"testing"
 
@@ -72,6 +73,8 @@ func (m *mockPDU) SetNetConn(_ net.Conn)                                        
 func (m *mockPDU) AddPresContexts(_ network.PresentationContext)                   {}
 func (m *mockPDU) SetOnAssociationRequest(_ func(network.AssociationRequest) bool) {}
 func (m *mockPDU) SetOnRawPDU(_ func(network.RawPDUEvent))                         {}
+func (m *mockPDU) SetLogger(_ *slog.Logger)                                        {}
+func (m *mockPDU) Logger() *slog.Logger                                            { return slog.Default() }
 func (m *mockPDU) GetAcceptedPresentationContexts() []network.PresentationContextAccept {
 	return nil
 }

--- a/network/a_association_ac.go
+++ b/network/a_association_ac.go
@@ -153,6 +153,12 @@ func (aaac *associationAccept) Write(rw *bufio.ReadWriter) error {
 		return err
 	}
 	for _, presContextAccept := range aaac.PresContextAccepts {
+		// Propagate the connection logger so the context's encode traces carry
+		// the same per-association correlation attributes rather than falling
+		// back to slog.Default().
+		if pc, ok := presContextAccept.(*presentationContextAccept); ok {
+			pc.logger = aaac.logger
+		}
 		if err := presContextAccept.Write(rw); err != nil {
 			return err
 		}

--- a/network/a_association_ac.go
+++ b/network/a_association_ac.go
@@ -43,6 +43,7 @@ type associationAccept struct {
 	AppContext         UIDItem
 	PresContextAccepts []PresentationContextAccept
 	UserInfo           *userInformation
+	logger             *slog.Logger
 }
 
 func newAssociationAccept() *associationAccept {
@@ -125,11 +126,13 @@ func (aaac *associationAccept) Size() uint32 {
 func (aaac *associationAccept) Write(rw *bufio.ReadWriter) error {
 	bd := media.NewDICOMBuffer()
 
-	slog.Info("ASSOC-AC:", "CallingAE", aaac.GetCallingAE(), "CalledAE", aaac.GetCalledAE())
-	slog.Info("ASSOC-AC:", "ImpClass", aaac.UserInfo.GetImplementationClass().GetUID())
-	slog.Info("ASSOC-AC:", "ImpVersion", aaac.UserInfo.GetImplementationVersion().GetUID())
-	slog.Info("ASSOC-AC:", "MaxPDULength", aaac.GetMaxSubLength())
-	slog.Info("ASSOC-AC:", "MaxOpsInvoked", aaac.UserInfo.AsyncOpWindow.GetMaxNumberOperationsInvoked(), "MaxOpsPerformed", aaac.UserInfo.AsyncOpWindow.GetMaxNumberOperationsPerformed())
+	loggerOrDefault(aaac.logger).Debug("encoding A-ASSOCIATE-AC",
+		"calling_ae", aaac.GetCallingAE(), "called_ae", aaac.GetCalledAE(),
+		"impl_class", aaac.UserInfo.GetImplementationClass().GetUID(),
+		"impl_version", aaac.UserInfo.GetImplementationVersion().GetUID(),
+		"max_pdu_length", aaac.GetMaxSubLength(),
+		"max_ops_invoked", aaac.UserInfo.AsyncOpWindow.GetMaxNumberOperationsInvoked(),
+		"max_ops_performed", aaac.UserInfo.AsyncOpWindow.GetMaxNumberOperationsPerformed())
 
 	bd.SetBigEndian(true)
 	aaac.Size()
@@ -208,19 +211,22 @@ func (aaac *associationAccept) ReadDynamic(buf *media.DICOMBuffer) (err error) {
 		}
 	}
 
-	slog.Debug("====================== BEGIN A-ASSOCIATE-AC ======================")
-	slog.Debug("ASSOC-AC:", "CallingAE", aaac.GetCallingAE(), "CalledAE", aaac.GetCalledAE())
-	slog.Debug("ASSOC-AC: OurImpClass", "UID", implementation.GetImplementationClassUID())
-	slog.Debug("ASSOC-AC: OurImpVersion", "name", implementation.GetImplementationVersion())
-	slog.Debug("ASSOC-AC: TheirImpClass", "UID", aaac.UserInfo.GetImplementationClass().GetUID())
-	slog.Debug("ASSOC-AC: TheirImpVersion", "name", aaac.UserInfo.GetImplementationVersion().GetUID())
-	slog.Debug("ASSOC-AC: AppContext", "UID", aaac.AppContext.GetUID(), "Description", sopclass.GetSOPClassFromUID(aaac.AppContext.GetUID()).Description)
-	slog.Debug("ASSOC-AC:", "OurMaxPDULength", maxPduLength, "TheirMaxPDULength", aaac.GetMaxSubLength())
+	aaLog := loggerOrDefault(aaac.logger)
+	aaLog.Debug("decoded A-ASSOCIATE-AC",
+		"calling_ae", aaac.GetCallingAE(), "called_ae", aaac.GetCalledAE(),
+		"our_impl_class", implementation.GetImplementationClassUID(),
+		"our_impl_version", implementation.GetImplementationVersion(),
+		"their_impl_class", aaac.UserInfo.GetImplementationClass().GetUID(),
+		"their_impl_version", aaac.UserInfo.GetImplementationVersion().GetUID(),
+		"app_context", aaac.AppContext.GetUID(),
+		"app_context_description", sopclass.GetSOPClassFromUID(aaac.AppContext.GetUID()).Description,
+		"our_max_pdu_length", maxPduLength, "their_max_pdu_length", aaac.GetMaxSubLength())
 	for presIndex, presContextAccept := range aaac.PresContextAccepts {
-		slog.Debug("ASSOC-AC: AcceptedContext", "Index", presIndex+1, "ID", presContextAccept.GetPresentationContextID(), "status", "Accepted")
-		slog.Debug("ASSOC-AC:   TransferSyntax:", "UID", presContextAccept.GetTrnSyntax().GetUID(), "Description", transfersyntax.GetTransferSyntaxFromUID(presContextAccept.GetTrnSyntax().GetUID()).Description)
+		aaLog.Debug("accepted presentation context",
+			"index", presIndex+1, "pcid", presContextAccept.GetPresentationContextID(),
+			"transfer_syntax", presContextAccept.GetTrnSyntax().GetUID(),
+			"transfer_syntax_description", transfersyntax.GetTransferSyntaxFromUID(presContextAccept.GetTrnSyntax().GetUID()).Description)
 	}
-	slog.Debug("======================= END A-ASSOCIATE-AC =======================")
 	if Count == 0 {
 		return nil
 	}

--- a/network/a_association_rj.go
+++ b/network/a_association_rj.go
@@ -81,6 +81,7 @@ type associationReject struct {
 	Result    byte
 	Source    byte
 	Reason    byte
+	logger    *slog.Logger
 }
 
 // NewAssociationReject creates an association reject
@@ -113,7 +114,7 @@ func (aarj *associationReject) Size() uint32 {
 func (aarj *associationReject) Write(rw *bufio.ReadWriter) error {
 	bd := media.NewDICOMBuffer()
 
-	slog.Info("ASSOC-RJ:", "Reason", aarj.GetReason())
+	loggerOrDefault(aarj.logger).Warn("association rejected", "reason", aarj.GetReason())
 
 	bd.SetBigEndian(true)
 	aarj.Size()

--- a/network/a_association_rq.go
+++ b/network/a_association_rq.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"log/slog"
-	"strconv"
 
 	"github.com/innovative-io/io-dicom/dictionary/sopclass"
 	"github.com/innovative-io/io-dicom/dictionary/transfersyntax"
@@ -57,6 +56,7 @@ type associationRequest struct {
 	PeerCertificates []*x509.Certificate
 	RemoteAddress    string
 	CorrelationID    string
+	logger           *slog.Logger
 }
 
 // NewAssociationRequest returns a new AssociationRequest with default settings.
@@ -180,11 +180,12 @@ func (aarq *associationRequest) Size() uint32 {
 func (aarq *associationRequest) Write(rw *bufio.ReadWriter) error {
 	bd := media.NewDICOMBuffer()
 
-	slog.Debug("====================== BEGIN A-ASSOCIATE-RQ ======================")
-	slog.Debug("ASSOC-RQ:", "CallingAE", aarq.GetCallingAE(), "CalledAE", aarq.GetCalledAE())
-	slog.Debug("ASSOC-RQ: OurImpClass", "UID", aarq.GetUserInformation().GetImplementationClass().GetUID())
-	slog.Debug("ASSOC-RQ: OurImpVersion", "name", aarq.GetUserInformation().GetImplementationVersion().GetUID())
-	slog.Debug("ASSOC-RQ:", "MaxPDULength", aarq.GetUserInformation().GetMaxSubLength().GetMaximumLength())
+	aaLog := loggerOrDefault(aarq.logger)
+	aaLog.Debug("encoding A-ASSOCIATE-RQ",
+		"calling_ae", aarq.GetCallingAE(), "called_ae", aarq.GetCalledAE(),
+		"impl_class", aarq.GetUserInformation().GetImplementationClass().GetUID(),
+		"impl_version", aarq.GetUserInformation().GetImplementationVersion().GetUID(),
+		"max_pdu_length", aarq.GetUserInformation().GetMaxSubLength().GetMaximumLength())
 
 	bd.SetBigEndian(true)
 	aarq.Size()
@@ -201,21 +202,23 @@ func (aarq *associationRequest) Write(rw *bufio.ReadWriter) error {
 		return err
 	}
 
-	slog.Debug("ASSOC-RQ: AppContext", "UID", aarq.AppContext.GetUID(), "Description", sopclass.GetSOPClassFromUID(aarq.AppContext.GetUID()).Description)
+	aaLog.Debug("application context", "uid", aarq.AppContext.GetUID(), "description", sopclass.GetSOPClassFromUID(aarq.AppContext.GetUID()).Description)
 	if err := aarq.AppContext.Write(rw); err != nil {
 		return err
 	}
 	for presIndex, presContext := range aarq.PresContexts {
-		slog.Debug("ASSOC-RQ: PresentationContext", "Index", presIndex+1, "ID", presContext.GetPresentationContextID(), "status", "Proposed")
-		slog.Debug("ASSOC-RQ:   AbstractSyntax:", "UID", presContext.GetAbstractSyntax().GetUID(), "Description", sopclass.GetSOPClassFromUID(presContext.GetAbstractSyntax().GetUID()).Description)
+		aaLog.Debug("proposed presentation context",
+			"index", presIndex+1, "pcid", presContext.GetPresentationContextID(),
+			"abstract_syntax", presContext.GetAbstractSyntax().GetUID(),
+			"abstract_syntax_description", sopclass.GetSOPClassFromUID(presContext.GetAbstractSyntax().GetUID()).Description)
 		for _, transSyntax := range presContext.GetTransferSyntaxes() {
-			slog.Debug("ASSOC-RQ:   TransferSyntax:", "UID", transSyntax.GetUID(), "Description", transfersyntax.GetTransferSyntaxFromUID(transSyntax.GetUID()).Description)
+			aaLog.Debug("proposed transfer syntax",
+				"uid", transSyntax.GetUID(), "description", transfersyntax.GetTransferSyntaxFromUID(transSyntax.GetUID()).Description)
 		}
 		if err := presContext.Write(rw); err != nil {
 			return err
 		}
 	}
-	slog.Debug("======================= END A-ASSOCIATE-RQ =======================")
 	return aarq.UserInfo.Write(rw)
 }
 
@@ -252,7 +255,7 @@ func (aarq *associationRequest) Read(buf *media.DICOMBuffer) (err error) {
 			aarq.UserInfo.ReadDynamic(buf)
 			return nil
 		default:
-			slog.Error("aarq::ReadDynamic, unknown Item " + strconv.Itoa(int(TempByte)))
+			loggerOrDefault(aarq.logger).Error("unknown A-ASSOCIATE-RQ item", "item_type", TempByte)
 			Count = -1
 		}
 	}

--- a/network/pdu_service.go
+++ b/network/pdu_service.go
@@ -76,6 +76,13 @@ type PDUService interface {
 	SetOnAssociationRequest(f func(request AssociationRequest) bool)
 	SetOnRawPDU(f func(event RawPDUEvent))
 	Write(DCO media.DICOMObject, ItemType byte) error
+	// SetLogger sets the structured logger used for this connection's PDU-level
+	// events. Passing a logger derived with per-association attributes (e.g.
+	// slog.With("assoc_id", ...)) tags every line so logs from concurrent
+	// associations can be correlated. A nil logger restores slog.Default().
+	SetLogger(logger *slog.Logger)
+	// Logger returns the logger configured for this connection, never nil.
+	Logger() *slog.Logger
 }
 
 // PDUServiceOption configures a PDUService at construction time.
@@ -88,6 +95,15 @@ func WithImplementationClass(uid, version string) PDUServiceOption {
 	return func(p *pduService) {
 		p.implClassUID = uid
 		p.implVersion = version
+	}
+}
+
+// WithLogger sets the structured logger used for PDU-level events on this
+// connection. By default the library logs through slog.Default(). Pass a logger
+// derived with per-association attributes to correlate concurrent associations.
+func WithLogger(logger *slog.Logger) PDUServiceOption {
+	return func(p *pduService) {
+		p.SetLogger(logger)
 	}
 }
 
@@ -110,6 +126,7 @@ type pduService struct {
 	onRawPDU                     func(event RawPDUEvent)
 	implClassUID                 string
 	implVersion                  string
+	logger                       *slog.Logger
 }
 
 // NewPDUService creates a PDUService. Pass PDUServiceOption values to
@@ -124,10 +141,44 @@ func NewPDUService(opts ...PDUServiceOption) PDUService {
 		ReleaseRP: NewReleaseResponse(),
 		AbortRQ:   NewAbortRequest(),
 	}
+	p.SetLogger(nil)
 	for _, opt := range opts {
 		opt(p)
 	}
 	return p
+}
+
+// SetLogger sets the connection logger and propagates it to the association
+// sub-structures so their PDU-encoding traces share the same correlation
+// attributes. A nil logger resets to slog.Default().
+func (pdu *pduService) SetLogger(logger *slog.Logger) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	pdu.logger = logger
+	pdu.AssocRQ.logger = logger
+	pdu.AssocAC.logger = logger
+	if aarj, ok := pdu.AssocRJ.(*associationReject); ok {
+		aarj.logger = logger
+	}
+}
+
+// Logger returns the connection logger, never nil.
+func (pdu *pduService) Logger() *slog.Logger {
+	if pdu.logger == nil {
+		return slog.Default()
+	}
+	return pdu.logger
+}
+
+// loggerOrDefault returns l, or slog.Default() when l is nil. Used by the
+// association sub-structures, which may be exercised standalone (e.g. in tests)
+// before a pduService propagates its connection logger to them.
+func loggerOrDefault(l *slog.Logger) *slog.Logger {
+	if l == nil {
+		return slog.Default()
+	}
+	return l
 }
 
 const maxPduLength uint32 = 16384
@@ -262,12 +313,12 @@ func (pdu *pduService) Connect(ctx context.Context, IP string, Port string) erro
 		defer cancel()
 	}
 
-	slog.Debug("pduservice::Connect", "host", IP, "port", Port)
+	pdu.logger.Debug("dialing", "host", IP, "port", Port)
 	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", IP+":"+Port)
 	if err != nil {
 		return fmt.Errorf("pduservice::Connect: %w", err)
 	}
-	slog.Debug("pduservice::Connect: TCP connected", "host", IP, "port", Port)
+	pdu.logger.Debug("tcp connected", "host", IP, "port", Port)
 	return pdu.finishConnect(conn)
 }
 
@@ -283,12 +334,12 @@ func (pdu *pduService) ConnectTLS(ctx context.Context, IP string, Port string, c
 		defer cancel()
 	}
 
-	slog.Debug("pduservice::ConnectTLS", "host", IP, "port", Port)
+	pdu.logger.Debug("dialing (tls)", "host", IP, "port", Port)
 	conn, err := (&tls.Dialer{Config: normalizeClientTLSConfig(cfg)}).DialContext(ctx, "tcp", IP+":"+Port)
 	if err != nil {
 		return fmt.Errorf("pduservice::ConnectTLS - %w", err)
 	}
-	slog.Debug("pduservice::ConnectTLS: TCP connected", "host", IP, "port", Port)
+	pdu.logger.Debug("tcp connected (tls)", "host", IP, "port", Port)
 	return pdu.finishConnect(conn)
 }
 
@@ -322,14 +373,14 @@ func (pdu *pduService) finishConnect(conn net.Conn) error {
 	pdu.AssocRQ.SetImplementationClassUID(scuUID)
 	pdu.AssocRQ.SetImplementationVersionName(scuVer)
 
-	slog.Debug("pduservice::finishConnect: sending A-ASSOCIATE-RQ", "callingAE", pdu.AssocRQ.GetCallingAE(), "calledAE", pdu.AssocRQ.GetCalledAE())
+	pdu.logger.Debug("sending A-ASSOCIATE-RQ", "calling_ae", pdu.AssocRQ.GetCallingAE(), "called_ae", pdu.AssocRQ.GetCalledAE())
 	if err := pdu.writeEncodedPDU(byte(pdutype.AssociationRequest), func(rw *bufio.ReadWriter) error {
 		return pdu.AssocRQ.Write(rw)
 	}); err != nil {
 		return err
 	}
 
-	slog.Debug("pduservice::finishConnect: waiting for A-ASSOCIATE response")
+	pdu.logger.Debug("waiting for A-ASSOCIATE response")
 	itemType, rawData, err := pdu.readIncomingPDU()
 	if err != nil {
 		return err
@@ -352,7 +403,7 @@ func (pdu *pduService) finishConnect(conn net.Conn) error {
 		if theirMaxPDU == 0 {
 			theirMaxStr = "unlimited"
 		}
-		slog.Info("Association Accepted", "maxSendPDV", maxSendPDV-6, "theirMaxPDU", theirMaxStr)
+		pdu.logger.Info("association accepted", "max_send_pdv", maxSendPDV-6, "their_max_pdu", theirMaxStr)
 		for _, pc := range pdu.AcceptedPresentationContexts {
 			pcID := pc.GetPresentationContextID()
 			sopDesc := ""
@@ -372,7 +423,7 @@ func (pdu *pduService) finishConnect(conn net.Conn) error {
 			} else {
 				tsDesc = pc.GetTrnSyntax().GetUID()
 			}
-			slog.Info("Accepted Context", "id", pcID, "sopClass", sopDesc, "transferSyntax", tsDesc)
+			pdu.logger.Debug("presentation context accepted", "pcid", pcID, "sop_class", sopDesc, "transfer_syntax", tsDesc)
 		}
 		return nil
 	case pdutype.AssociationReject:
@@ -395,11 +446,11 @@ func (pdu *pduService) Close() error {
 		return nil
 	}
 
-	slog.Info("Releasing Association")
+	pdu.logger.Debug("releasing association")
 	if err := pdu.writeEncodedPDU(byte(pdutype.AssociationReleaseRequest), func(rw *bufio.ReadWriter) error {
 		return pdu.ReleaseRQ.Write(rw)
 	}); err != nil {
-		slog.Warn("pduservice::Close - failed to send A-RELEASE-RQ, sending A-ABORT", "error", err)
+		pdu.logger.Warn("failed to send A-RELEASE-RQ; sending A-ABORT", "error", err)
 		_ = pdu.writeEncodedPDU(byte(pdutype.AssociationAbortRequest), func(rw *bufio.ReadWriter) error {
 			return pdu.AbortRQ.Write(rw)
 		})
@@ -413,7 +464,7 @@ func (pdu *pduService) Close() error {
 
 	itemType, rawData, err := pdu.readIncomingPDU()
 	if err != nil {
-		slog.Warn("pduservice::Close - timeout waiting for A-RELEASE-RP, sending A-ABORT", "error", err)
+		pdu.logger.Warn("timeout waiting for A-RELEASE-RP; sending A-ABORT", "error", err)
 		_ = pdu.writeEncodedPDU(byte(pdutype.AssociationAbortRequest), func(rw *bufio.ReadWriter) error {
 			return pdu.AbortRQ.Write(rw)
 		})
@@ -423,7 +474,7 @@ func (pdu *pduService) Close() error {
 
 	pdu.emitRawPDU(RawPDUDirectionInbound, itemType, rawData)
 	if int(itemType) != pdutype.AssociationReleaseResponse {
-		slog.Warn("pduservice::Close - unexpected PDU waiting for A-RELEASE-RP", "type", itemType)
+		pdu.logger.Warn("unexpected PDU waiting for A-RELEASE-RP", "pdu_type", itemType)
 	}
 
 	pdu.closeConn()
@@ -492,7 +543,7 @@ func (pdu *pduService) NextPDU() (command media.DICOMObject, err error) {
 				return DCO, nil
 			}
 		case pdutype.AssociationReleaseRequest:
-			slog.Info("ASSOC-R-RQ:", "CallingAE", pdu.AssocRQ.GetCallingAE(), "CalledAE", pdu.AssocRQ.GetCalledAE())
+			pdu.logger.Debug("A-RELEASE-RQ received")
 			pdu.emitRawPDU(RawPDUDirectionInbound, itemType, rawData)
 			pdu.buf.SetPosition(1)
 			pdu.ReleaseRQ.ReadDynamic(pdu.buf)
@@ -503,11 +554,11 @@ func (pdu *pduService) NextPDU() (command media.DICOMObject, err error) {
 			}
 			return nil, ErrAssociationReleased
 		case pdutype.AssociationReleaseResponse:
-			slog.Info("ASSOC-R-RP:", "CallingAE", pdu.AssocRQ.GetCallingAE(), "CalledAE", pdu.AssocRQ.GetCalledAE())
+			pdu.logger.Debug("A-RELEASE-RP received")
 			pdu.emitRawPDU(RawPDUDirectionInbound, itemType, rawData)
 			return nil, ErrAssociationReleased
 		case pdutype.AssociationAbortRequest:
-			slog.Info("ASSOC-ABORT-RQ:", "CallingAE", pdu.AssocRQ.GetCallingAE(), "CalledAE", pdu.AssocRQ.GetCalledAE())
+			pdu.logger.Info("A-ABORT received")
 			pdu.emitRawPDU(RawPDUDirectionInbound, itemType, rawData)
 			return nil, ErrAssociationAborted
 		default:
@@ -697,9 +748,9 @@ func (pdu *pduService) Write(DCO media.DICOMObject, ItemType byte) error {
 		sopClassUID := DCO.GetString(tags.AffectedSOPClassUID)
 		sopClass := sopclass.GetSOPClassFromUID(sopClassUID)
 		if sopClass != nil {
-			slog.Debug("PDU-Service: SOP Class", "UID", sopClass.UID, "Description", sopClass.Description, "CalledAE", pdu.GetCalledAE())
+			pdu.logger.Debug("negotiating SOP class", "uid", sopClass.UID, "description", sopClass.Description)
 		} else {
-			slog.Debug("PDU-Service: SOP Class", "UID", sopClassUID, "Description", "Unknown SOP Class", "CalledAE", pdu.GetCalledAE())
+			pdu.logger.Debug("negotiating SOP class", "uid", sopClassUID, "description", "Unknown SOP Class")
 		}
 	}
 
@@ -762,7 +813,7 @@ func (pdu *pduService) interogateAAssociateRQ(rw *bufio.ReadWriter) error {
 	}
 
 	if pdu.OnAssociationRequest == nil || !pdu.OnAssociationRequest(pdu.AssocRQ) {
-		slog.Warn("pdu: rejecting association - rejected by application handler", "CalledAE", pdu.AssocRQ.GetCalledAE(), "CallingAE", pdu.AssocRQ.GetCallingAE())
+		pdu.logger.Warn("rejecting association: rejected by application handler")
 		// Result=1 (permanent), Source=1 (UL-service-user), Reason=7 (called AE not recognised)
 		// per DICOM PS3.8 Table 9-21.
 		pdu.AssocRJ.Set(1, 1, 7)
@@ -777,16 +828,17 @@ func (pdu *pduService) interogateAAssociateRQ(rw *bufio.ReadWriter) error {
 
 	pdu.AcceptedPresentationContexts = nil
 	pdu.AssocAC = newAssociationAccept()
+	pdu.AssocAC.logger = pdu.logger
 	pdu.AssocAC.SetCalledAE(pdu.AssocRQ.GetCalledAE())
 	pdu.AssocAC.SetCallingAE(pdu.AssocRQ.GetCallingAE())
 	pdu.AssocAC.SetAppContext(pdu.AssocRQ.GetAppContext())
 
-	slog.Info("ASSOC-RQ:", "CallingAE", pdu.AssocRQ.GetCallingAE(), "CalledAE", pdu.AssocRQ.GetCalledAE())
-	slog.Debug("ASSOC-RQ:", "ImpClass", pdu.AssocRQ.GetImplementationClass().GetUID())
-	slog.Debug("ASSOC-RQ:", "MaxPDULength", pdu.AssocRQ.GetMaxSubLength())
+	pdu.logger.Debug("association request received", "calling_ae", pdu.AssocRQ.GetCallingAE(), "called_ae", pdu.AssocRQ.GetCalledAE())
+	pdu.logger.Debug("association request impl class", "impl_class", pdu.AssocRQ.GetImplementationClass().GetUID())
+	pdu.logger.Debug("association request max PDU length", "max_pdu_length", pdu.AssocRQ.GetMaxSubLength())
 
 	for presIndex, PresContext := range pdu.AssocRQ.GetPresContexts() {
-		slog.Debug("ASSOC-RQ: PresentationContext", "Index", presIndex)
+		pdu.logger.Debug("proposed presentation context", "index", presIndex)
 
 		sopClass := sopclass.GetSOPClassFromUID(PresContext.GetAbstractSyntax().GetUID())
 		sopUID := PresContext.GetAbstractSyntax().GetUID()
@@ -795,14 +847,14 @@ func (pdu *pduService) interogateAAssociateRQ(rw *bufio.ReadWriter) error {
 			sopUID = sopClass.UID
 			sopDescription = sopClass.Description
 		}
-		slog.Debug("ASSOC-RQ: \tAbstractContext", "UID", sopUID, "Description", sopDescription)
+		pdu.logger.Debug("proposed abstract syntax", "uid", sopUID, "description", sopDescription)
 		for _, TransferSyn := range PresContext.GetTransferSyntaxes() {
 			tsName := ""
 			transferSyntax := transfersyntax.GetTransferSyntaxFromUID(TransferSyn.GetUID())
 			if transferSyntax != nil {
 				tsName = transferSyntax.Description
 			}
-			slog.Debug("ASSOC-RQ: \tTransferSyntax:", "UID", TransferSyn.GetUID(), "Description", tsName)
+			pdu.logger.Debug("proposed transfer syntax", "uid", TransferSyn.GetUID(), "description", tsName)
 		}
 
 		PresContextAccept := NewPresentationContextAccept()
@@ -845,7 +897,7 @@ func (pdu *pduService) interogateAAssociateRQ(rw *bufio.ReadWriter) error {
 		})
 	}
 
-	slog.Warn("pdu: rejecting association - no presentation contexts could be negotiated", "CalledAE", pdu.AssocRQ.GetCalledAE(), "CallingAE", pdu.AssocRQ.GetCallingAE())
+	pdu.logger.Warn("rejecting association: no presentation contexts negotiated")
 	return pdu.writeEncodedPDU(byte(pdutype.AssociationReject), func(rw *bufio.ReadWriter) error {
 		return pdu.AssocRJ.Write(rw)
 	})
@@ -859,7 +911,7 @@ func (pdu *pduService) parseDCMIntoRaw(DCO media.DICOMObject) bool {
 func (pdu *pduService) parseRawVRIntoDCM(DCO media.DICOMObject) bool {
 	TrnSyntax := pdu.GetTransferSyntax(pdu.Pdata.PresentationContextID)
 	if TrnSyntax == nil {
-		slog.Error("pdu: no transfer syntax for presentation context", "PCID", pdu.Pdata.PresentationContextID)
+		pdu.logger.Error("no transfer syntax for presentation context", "pcid", pdu.Pdata.PresentationContextID)
 		return false
 	}
 	DCO.SetTransferSyntax(TrnSyntax)

--- a/network/presentation_context_accept.go
+++ b/network/presentation_context_accept.go
@@ -36,6 +36,7 @@ type presentationContextAccept struct {
 	Reserved4             byte
 	AbsSyntax             uidItem
 	TrnSyntax             uidItem
+	logger                *slog.Logger
 }
 
 // NewPresentationContextAccept creates a PresentationContextAccept
@@ -114,8 +115,9 @@ func (pc *presentationContextAccept) Write(rw *bufio.ReadWriter) (err error) {
 		tsName = transferSyntax.Description
 	}
 
-	slog.Debug("accepted abstract syntax", "uid", pc.GetAbstractSyntax().GetUID(), "description", sopName)
-	slog.Debug("accepted transfer syntax", "uid", pc.GetTrnSyntax().GetUID(), "description", tsName)
+	pcLog := loggerOrDefault(pc.logger)
+	pcLog.Debug("accepted abstract syntax", "uid", pc.GetAbstractSyntax().GetUID(), "description", sopName)
+	pcLog.Debug("accepted transfer syntax", "uid", pc.GetTrnSyntax().GetUID(), "description", tsName)
 
 	if err = bd.Send(rw); err == nil {
 		return pc.TrnSyntax.Write(rw)

--- a/network/presentation_context_accept.go
+++ b/network/presentation_context_accept.go
@@ -114,8 +114,8 @@ func (pc *presentationContextAccept) Write(rw *bufio.ReadWriter) (err error) {
 		tsName = transferSyntax.Description
 	}
 
-	slog.Debug("ASSOC-AC:   Accepted AbstractContext:", "UID", pc.GetAbstractSyntax().GetUID(), "Description", sopName)
-	slog.Debug("ASSOC-AC:   Accepted TransferSyntax:", "UID", pc.GetTrnSyntax().GetUID(), "Description", tsName)
+	slog.Debug("accepted abstract syntax", "uid", pc.GetAbstractSyntax().GetUID(), "description", sopName)
+	slog.Debug("accepted transfer syntax", "uid", pc.GetTrnSyntax().GetUID(), "description", tsName)
 
 	if err = bd.Send(rw); err == nil {
 		return pc.TrnSyntax.Write(rw)

--- a/services/scp.go
+++ b/services/scp.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"crypto/tls"
+	"log/slog"
 	"net"
 	"sync"
 	"time"
@@ -126,6 +127,7 @@ type scp struct {
 	implVersion     string
 	timeout         int
 	maxAssociations int
+	logger          *slog.Logger
 }
 
 // SCPOption configures an SCP at construction time.
@@ -164,6 +166,18 @@ func WithCancelGraceWindow(d time.Duration) SCPOption {
 	}
 }
 
+// WithLogger sets the structured logger for the SCP. Each accepted association
+// derives a child logger carrying correlation attributes (assoc_id, remote_addr,
+// and the negotiated AE titles), so log lines from concurrent associations can
+// be told apart. Defaults to slog.Default() when unset.
+func WithLogger(logger *slog.Logger) SCPOption {
+	return func(s *scp) {
+		if logger != nil {
+			s.logger = logger
+		}
+	}
+}
+
 // WithMaxAssociations bounds the number of associations the SCP will service
 // concurrently. Connections accepted beyond the limit block in the accept loop
 // (applying TCP backpressure) until an in-flight association completes, rather
@@ -193,6 +207,7 @@ func NewSCP(port int, opts ...SCPOption) SCP {
 		bufSize:            scpBufSize,
 		cancelPoll:         cancelPollWindow,
 		cancelGrace:        cancelGraceWindow,
+		logger:             slog.Default(),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -210,6 +225,7 @@ func NewSCPWithTLS(port int, cfg *tls.Config, opts ...SCPOption) SCP {
 		bufSize:            scpBufSize,
 		cancelPoll:         cancelPollWindow,
 		cancelGrace:        cancelGraceWindow,
+		logger:             slog.Default(),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -229,15 +245,26 @@ func normalizeServerTLSConfig(cfg *tls.Config) *tls.Config {
 }
 
 // newPDUService creates a PDUService, applying a per-SCP implementation class
-// override and timeout if configured.
+// override and timeout if configured. The configuration fields are read under
+// the mutex because they can be mutated concurrently (e.g. SetTimeout) while
+// the accept loop is spawning connection handlers.
 func (s *scp) newPDUService() network.PDUService {
+	s.mu.RLock()
+	implClassUID, implVersion := s.implClassUID, s.implVersion
+	logger := s.logger
+	timeout := s.timeout
+	s.mu.RUnlock()
+
 	var opts []network.PDUServiceOption
-	if s.implClassUID != "" || s.implVersion != "" {
-		opts = append(opts, network.WithImplementationClass(s.implClassUID, s.implVersion))
+	if implClassUID != "" || implVersion != "" {
+		opts = append(opts, network.WithImplementationClass(implClassUID, implVersion))
+	}
+	if logger != nil {
+		opts = append(opts, network.WithLogger(logger))
 	}
 	pdu := network.NewPDUService(opts...)
-	if s.timeout > 0 {
-		pdu.SetTimeout(s.timeout)
+	if timeout > 0 {
+		pdu.SetTimeout(timeout)
 	}
 	return pdu
 }

--- a/services/scp_association.go
+++ b/services/scp_association.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/innovative-io/io-dicom/dictionary/tags"
@@ -17,6 +18,14 @@ import (
 	"github.com/innovative-io/io-dicom/network/dicomcommand"
 	"github.com/innovative-io/io-dicom/network/dicomstatus"
 )
+
+// assocCounter assigns each accepted association a process-unique, monotonically
+// increasing id used to correlate its log lines.
+var assocCounter atomic.Uint64
+
+func nextAssocID() uint64 {
+	return assocCounter.Add(1)
+}
 
 func abortAssociation(rw *bufio.ReadWriter, conn net.Conn) {
 	if rw != nil {
@@ -58,7 +67,7 @@ func (s *scp) consumeCanceled(messageID uint16) bool {
 	return ok
 }
 
-func (s *scp) handleCancelCommand(assocRQ network.AssociationRequest, dco media.DICOMObject) uint16 {
+func (s *scp) handleCancelCommand(log *slog.Logger, assocRQ network.AssociationRequest, dco media.DICOMObject) uint16 {
 	messageID := dco.GetUint16(tags.MessageIDBeingRespondedTo)
 	s.markCanceled(messageID)
 
@@ -69,7 +78,7 @@ func (s *scp) handleCancelCommand(assocRQ network.AssociationRequest, dco media.
 		cancelHandler(assocRQ, messageID)
 	}
 
-	slog.Info("scp: C-CANCEL received", "message_id_being_responded_to", messageID)
+	log.Info("C-CANCEL received", "message_id_being_responded_to", messageID)
 	return messageID
 }
 
@@ -104,6 +113,15 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 	pdu.SetConn(rw)
 	pdu.SetNetConn(conn)
 
+	// Per-association logger: tag every line with a process-unique id and the
+	// peer address from the outset, then enrich with the negotiated AE titles
+	// once the association is established.
+	connLog := s.logger.With(
+		"assoc_id", nextAssocID(),
+		"remote_addr", conn.RemoteAddr().String(),
+	)
+	pdu.SetLogger(connLog)
+
 	s.mu.RLock()
 	assocHandler := s.onAssociationRequest
 	onRawPDU := s.onRawPDU
@@ -115,6 +133,7 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 
 	defer conn.Close()
 	queuedCommands := make([]media.DICOMObject, 0, 1)
+	negotiated := false
 
 	for {
 		var (
@@ -129,14 +148,19 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			dco, err = pdu.NextPDU()
 			if err != nil {
 				if errors.Is(err, io.EOF) {
-					slog.Debug("scp: connection closed (EOF)", "ADDRESS", conn.RemoteAddr())
+					pdu.Logger().Debug("connection closed (EOF)")
 				} else if !errors.Is(err, network.ErrAssociationReleased) &&
 					!errors.Is(err, network.ErrAssociationAborted) &&
 					!errors.Is(err, network.ErrAssociationRejected) {
-					slog.Error("scp: network error", "ERROR", err)
+					pdu.Logger().Error("network error", "error", err)
 				}
 				return
 			}
+		}
+		if !negotiated {
+			negotiated = true
+			connLog = connLog.With("calling_ae", pdu.GetCallingAE(), "called_ae", pdu.GetCalledAE())
+			pdu.SetLogger(connLog)
 		}
 		if dco == nil {
 			continue
@@ -146,7 +170,7 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 		case dicomcommand.CStoreRequest:
 			ddo, err := pdu.NextPDU()
 			if err != nil {
-				slog.Error("scp: C-Store failed to read request", "ERROR", err.Error())
+				pdu.Logger().Error("C-Store failed to read request", "error", err)
 				return
 			}
 
@@ -155,9 +179,9 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			s.mu.RUnlock()
 
 			if storeHandler == nil {
-				slog.Warn("scp: OnCStoreRequest not registered")
+				pdu.Logger().Warn("OnCStoreRequest not registered")
 				if err := dimse.CStoreWriteRSP(pdu, dco, dicomstatus.FailureProcessingFailure); err != nil {
-					slog.Error("scp: C-Store failed to write error response", "ERROR", err.Error())
+					pdu.Logger().Error("C-Store failed to write error response", "error", err)
 					return
 				}
 				continue
@@ -165,26 +189,26 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 
 			status := storeHandler(ctx, pdu.GetAAssociationRQ(), ddo)
 			if err := dimse.CStoreWriteRSP(pdu, dco, status); err != nil {
-				slog.Error("scp: C-Store failed to write response", "ERROR", err.Error())
+				pdu.Logger().Error("C-Store failed to write response", "error", err)
 				return
 			}
 
 		case dicomcommand.CFindRequest:
 			ddo, err := pdu.NextPDU()
 			if err != nil {
-				slog.Error("scp: C-Find failed to read request", "ERROR", err.Error())
+				pdu.Logger().Error("C-Find failed to read request", "error", err)
 				return
 			}
 			if !isValidCFindQueryRetrieveLevel(ddo.GetString(tags.QueryRetrieveLevel)) {
 				if err := dimse.CFindWriteRSP(pdu, dco, media.NewEmptyDCMObj(), dicomstatus.FailureIdentifierDoesNotMatchSOPClass); err != nil {
-					slog.Error("scp: C-Find failed to write invalid-identifier response", "ERROR", err.Error())
+					pdu.Logger().Error("C-Find failed to write invalid-identifier response", "error", err)
 					return
 				}
 				continue
 			}
 			if s.consumeCanceled(dco.GetUint16(tags.MessageID)) {
 				if err := dimse.CFindWriteRSP(pdu, dco, media.NewEmptyDCMObj(), dicomstatus.Cancel); err != nil {
-					slog.Error("scp: C-Find failed to write cancel response", "ERROR", err.Error())
+					pdu.Logger().Error("C-Find failed to write cancel response", "error", err)
 					return
 				}
 				continue
@@ -195,9 +219,9 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			s.mu.RUnlock()
 
 			if findHandler == nil {
-				slog.Warn("scp: OnCFindRequest not registered")
+				pdu.Logger().Warn("OnCFindRequest not registered")
 				if err := dimse.CFindWriteRSP(pdu, dco, media.NewEmptyDCMObj(), dicomstatus.FailureProcessingFailure); err != nil {
-					slog.Error("scp: C-Find failed to write error response", "ERROR", err.Error())
+					pdu.Logger().Error("C-Find failed to write error response", "error", err)
 					return
 				}
 				continue
@@ -205,26 +229,26 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 
 			queryLevel := ddo.GetString(tags.QueryRetrieveLevel)
 			if err := s.runCFindOperation(rw, conn, pdu, &queuedCommands, dco, pdu.GetAAssociationRQ(), queryLevel, ddo, findHandler); err != nil {
-				slog.Error("scp: C-Find operation failed", "ERROR", err.Error())
+				pdu.Logger().Error("C-Find operation failed", "error", err)
 				return
 			}
 
 		case dicomcommand.CGetRequest:
 			ddo, err := pdu.NextPDU()
 			if err != nil {
-				slog.Error("scp: C-Get failed to read request", "ERROR", err.Error())
+				pdu.Logger().Error("C-Get failed to read request", "error", err)
 				return
 			}
 			if !isValidQueryRetrieveLevel(ddo.GetString(tags.QueryRetrieveLevel)) {
 				if err := dimse.CGetWriteRSP(pdu, dco, dicomstatus.FailureIdentifierDoesNotMatchSOPClass, 0, 0, 0, 0); err != nil {
-					slog.Error("scp: C-Get failed to write invalid-identifier response", "ERROR", err.Error())
+					pdu.Logger().Error("C-Get failed to write invalid-identifier response", "error", err)
 					return
 				}
 				continue
 			}
 			if s.consumeCanceled(dco.GetUint16(tags.MessageID)) {
 				if err := dimse.CGetWriteRSP(pdu, dco, dicomstatus.Cancel, 0, 0, 0, 0); err != nil {
-					slog.Error("scp: C-Get failed to write cancel response", "ERROR", err.Error())
+					pdu.Logger().Error("C-Get failed to write cancel response", "error", err)
 					return
 				}
 				continue
@@ -235,9 +259,9 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			s.mu.RUnlock()
 
 			if getHandler == nil {
-				slog.Warn("scp: OnCGetRequest not registered")
+				pdu.Logger().Warn("OnCGetRequest not registered")
 				if err := dimse.CGetWriteRSP(pdu, dco, dicomstatus.FailureSOPClassNotSupported, 0, 0, 0, 0); err != nil {
-					slog.Error("scp: C-Get failed to write error response", "ERROR", err.Error())
+					pdu.Logger().Error("C-Get failed to write error response", "error", err)
 					return
 				}
 				continue
@@ -245,26 +269,26 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 
 			getLevel := ddo.GetString(tags.QueryRetrieveLevel)
 			if err := s.runCGetOperation(rw, conn, pdu, &queuedCommands, dco, pdu.GetAAssociationRQ(), getLevel, ddo, getHandler); err != nil {
-				slog.Error("scp: C-Get operation failed", "ERROR", err.Error())
+				pdu.Logger().Error("C-Get operation failed", "error", err)
 				return
 			}
 
 		case dicomcommand.CMoveRequest:
 			ddo, err := pdu.NextPDU()
 			if err != nil {
-				slog.Error("scp: C-Move failed to read request", "ERROR", err.Error())
+				pdu.Logger().Error("C-Move failed to read request", "error", err)
 				return
 			}
 			if !isValidQueryRetrieveLevel(ddo.GetString(tags.QueryRetrieveLevel)) {
 				if err := dimse.CMoveWriteRSP(pdu, dco, dicomstatus.FailureIdentifierDoesNotMatchSOPClass, 0, 0, 0, 0); err != nil {
-					slog.Error("scp: C-Move failed to write invalid-identifier response", "ERROR", err.Error())
+					pdu.Logger().Error("C-Move failed to write invalid-identifier response", "error", err)
 					return
 				}
 				continue
 			}
 			if s.consumeCanceled(dco.GetUint16(tags.MessageID)) {
 				if err := dimse.CMoveWriteRSP(pdu, dco, dicomstatus.Cancel, 0, 0, 0, 0); err != nil {
-					slog.Error("scp: C-Move failed to write cancel response", "ERROR", err.Error())
+					pdu.Logger().Error("C-Move failed to write cancel response", "error", err)
 					return
 				}
 				continue
@@ -275,9 +299,9 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			s.mu.RUnlock()
 
 			if moveHandler == nil {
-				slog.Warn("scp: OnCMoveRequest not registered")
+				pdu.Logger().Warn("OnCMoveRequest not registered")
 				if err := dimse.CMoveWriteRSP(pdu, dco, dicomstatus.FailureProcessingFailure, 0, 0, 0, 0); err != nil {
-					slog.Error("scp: C-Move failed to write error response", "ERROR", err.Error())
+					pdu.Logger().Error("C-Move failed to write error response", "error", err)
 					return
 				}
 				continue
@@ -286,7 +310,7 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			moveLevel := ddo.GetString(tags.QueryRetrieveLevel)
 			moveDestAE := dco.GetString(tags.MoveDestination)
 			if err := s.runCMoveOperation(rw, conn, pdu, &queuedCommands, dco, pdu.GetAAssociationRQ(), moveDestAE, moveLevel, ddo, moveHandler); err != nil {
-				slog.Error("scp: C-Move operation failed", "ERROR", err.Error())
+				pdu.Logger().Error("C-Move operation failed", "error", err)
 				return
 			}
 
@@ -295,7 +319,7 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			if dco.GetUint16(tags.CommandDataSetType) != dicomcommand.DataSetNone {
 				nData, err = pdu.NextPDU()
 				if err != nil {
-					slog.Error("scp: N-Event-Report failed to read request dataset", "ERROR", err.Error())
+					pdu.Logger().Error("N-Event-Report failed to read request dataset", "error", err)
 					return
 				}
 			}
@@ -308,7 +332,7 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 				status, resp = h(ctx, pdu.GetAAssociationRQ(), dco, nData)
 			}
 			if err := dimse.NWriteRSP(pdu, dco, dicomcommand.NEventReportResponse, status, resp); err != nil {
-				slog.Error("scp: N-Event-Report failed to write response", "ERROR", err.Error())
+				pdu.Logger().Error("N-Event-Report failed to write response", "error", err)
 				return
 			}
 
@@ -317,7 +341,7 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			if dco.GetUint16(tags.CommandDataSetType) != dicomcommand.DataSetNone {
 				nData, err = pdu.NextPDU()
 				if err != nil {
-					slog.Error("scp: N-Get failed to read request dataset", "ERROR", err.Error())
+					pdu.Logger().Error("N-Get failed to read request dataset", "error", err)
 					return
 				}
 			}
@@ -330,7 +354,7 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 				status, resp = h(ctx, pdu.GetAAssociationRQ(), dco, nData)
 			}
 			if err := dimse.NWriteRSP(pdu, dco, dicomcommand.NGetResponse, status, resp); err != nil {
-				slog.Error("scp: N-Get failed to write response", "ERROR", err.Error())
+				pdu.Logger().Error("N-Get failed to write response", "error", err)
 				return
 			}
 
@@ -339,7 +363,7 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			if dco.GetUint16(tags.CommandDataSetType) != dicomcommand.DataSetNone {
 				nData, err = pdu.NextPDU()
 				if err != nil {
-					slog.Error("scp: N-Set failed to read request dataset", "ERROR", err.Error())
+					pdu.Logger().Error("N-Set failed to read request dataset", "error", err)
 					return
 				}
 			}
@@ -352,7 +376,7 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 				status, resp = h(ctx, pdu.GetAAssociationRQ(), dco, nData)
 			}
 			if err := dimse.NWriteRSP(pdu, dco, dicomcommand.NSetResponse, status, resp); err != nil {
-				slog.Error("scp: N-Set failed to write response", "ERROR", err.Error())
+				pdu.Logger().Error("N-Set failed to write response", "error", err)
 				return
 			}
 
@@ -361,7 +385,7 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			if dco.GetUint16(tags.CommandDataSetType) != dicomcommand.DataSetNone {
 				nData, err = pdu.NextPDU()
 				if err != nil {
-					slog.Error("scp: N-Action failed to read request dataset", "ERROR", err.Error())
+					pdu.Logger().Error("N-Action failed to read request dataset", "error", err)
 					return
 				}
 			}
@@ -374,7 +398,7 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 				status, resp = h(ctx, pdu.GetAAssociationRQ(), dco, nData)
 			}
 			if err := dimse.NWriteRSP(pdu, dco, dicomcommand.NActionResponse, status, resp); err != nil {
-				slog.Error("scp: N-Action failed to write response", "ERROR", err.Error())
+				pdu.Logger().Error("N-Action failed to write response", "error", err)
 				return
 			}
 
@@ -383,7 +407,7 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			if dco.GetUint16(tags.CommandDataSetType) != dicomcommand.DataSetNone {
 				nData, err = pdu.NextPDU()
 				if err != nil {
-					slog.Error("scp: N-Create failed to read request dataset", "ERROR", err.Error())
+					pdu.Logger().Error("N-Create failed to read request dataset", "error", err)
 					return
 				}
 			}
@@ -396,7 +420,7 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 				status, resp = h(ctx, pdu.GetAAssociationRQ(), dco, nData)
 			}
 			if err := dimse.NWriteRSP(pdu, dco, dicomcommand.NCreateResponse, status, resp); err != nil {
-				slog.Error("scp: N-Create failed to write response", "ERROR", err.Error())
+				pdu.Logger().Error("N-Create failed to write response", "error", err)
 				return
 			}
 
@@ -405,7 +429,7 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			if dco.GetUint16(tags.CommandDataSetType) != dicomcommand.DataSetNone {
 				nData, err = pdu.NextPDU()
 				if err != nil {
-					slog.Error("scp: N-Delete failed to read request dataset", "ERROR", err.Error())
+					pdu.Logger().Error("N-Delete failed to read request dataset", "error", err)
 					return
 				}
 			}
@@ -418,13 +442,13 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 				status, resp = h(ctx, pdu.GetAAssociationRQ(), dco, nData)
 			}
 			if err := dimse.NWriteRSP(pdu, dco, dicomcommand.NDeleteResponse, status, resp); err != nil {
-				slog.Error("scp: N-Delete failed to write response", "ERROR", err.Error())
+				pdu.Logger().Error("N-Delete failed to write response", "error", err)
 				return
 			}
 
 		case dicomcommand.CCancelRequest:
 			// C-CANCEL-RQ applies to in-progress C-FIND/C-MOVE/C-GET operations.
-			s.handleCancelCommand(pdu.GetAAssociationRQ(), dco)
+			s.handleCancelCommand(pdu.Logger(), pdu.GetAAssociationRQ(), dco)
 
 		case dicomcommand.CEchoRequest:
 			s.mu.RLock()
@@ -432,16 +456,16 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			s.mu.RUnlock()
 
 			if echoHandler != nil && !echoHandler(pdu.GetAAssociationRQ()) {
-				slog.Warn("scp: C-Echo rejected by handler")
+				pdu.Logger().Warn("C-Echo rejected by handler")
 				return
 			}
 			if err := dimse.CEchoWriteRSP(pdu, dco); err != nil {
-				slog.Error("scp: C-Echo failed to write response", "ERROR", err.Error())
+				pdu.Logger().Error("C-Echo failed to write response", "error", err)
 				return
 			}
 
 		default:
-			slog.Warn("scp: command not implemented, skipping", "COMMAND", command)
+			pdu.Logger().Warn("command not implemented, skipping", "command", command)
 		}
 	}
 }

--- a/services/scp_handlers.go
+++ b/services/scp_handlers.go
@@ -196,7 +196,7 @@ func (s *scp) runSubopLoop(
 			}
 
 			if dco.GetUint16(tags.CommandField) == dicomcommand.CCancelRequest {
-				cancelMessageID := s.handleCancelCommand(assocRQ, dco)
+				cancelMessageID := s.handleCancelCommand(pdu.Logger(), assocRQ, dco)
 				if cancelMessageID == messageID {
 					canceled = true
 					if cancelDeadline.IsZero() {
@@ -296,7 +296,7 @@ func (s *scp) runCFindOperation(rw *bufio.ReadWriter, conn net.Conn, pdu network
 			}
 
 			if dco.GetUint16(tags.CommandField) == dicomcommand.CCancelRequest {
-				cancelMessageID := s.handleCancelCommand(assocRQ, dco)
+				cancelMessageID := s.handleCancelCommand(pdu.Logger(), assocRQ, dco)
 				if cancelMessageID == messageID {
 					canceled = true
 					if cancelDeadline.IsZero() {
@@ -471,7 +471,7 @@ func (s *scp) runCGetOperation(rw *bufio.ReadWriter, conn net.Conn, pdu network.
 				continue
 			}
 			if dco.GetUint16(tags.CommandField) == dicomcommand.CCancelRequest {
-				cancelMessageID := s.handleCancelCommand(assocRQ, dco)
+				cancelMessageID := s.handleCancelCommand(pdu.Logger(), assocRQ, dco)
 				if cancelMessageID == messageID {
 					canceled = true
 					if cancelDeadline.IsZero() {

--- a/services/scp_logger_test.go
+++ b/services/scp_logger_test.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/network"
+)
+
+// syncBuffer is a goroutine-safe io.Writer so the SCP's logging goroutine and
+// the test goroutine can share one buffer without racing.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// TestSCP_WithLogger_RoutesAndCorrelates verifies that WithLogger directs the
+// SCP's structured output to the injected logger (rather than slog.Default())
+// and that each association's lines carry the assoc_id and remote_addr
+// correlation attributes.
+func TestSCP_WithLogger_RoutesAndCorrelates(t *testing.T) {
+	const port = 1102
+	var sink syncBuffer
+	logger := slog.New(slog.NewJSONHandler(&sink, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	_, testSCP := StartSCP(t, port, WithLogger(logger))
+	testSCP.OnAssociationRequest(func(network.AssociationRequest) bool { return true })
+	testSCP.OnCEchoRequest(func(network.AssociationRequest) bool { return true })
+
+	dest := &network.Destination{
+		Name:      "LoggerTest",
+		CalledAE:  "SCP",
+		CallingAE: "SCU",
+		HostName:  "localhost",
+		Port:      port,
+	}
+	if err := NewSCU(dest).EchoSCU(context.Background()); err != nil {
+		t.Fatalf("EchoSCU: %v", err)
+	}
+
+	out := sink.String()
+	if out == "" {
+		t.Fatal("injected logger received no output; SCP is still logging to slog.Default()")
+	}
+	if !strings.Contains(out, "assoc_id") {
+		t.Errorf("SCP log lines missing assoc_id correlation attribute:\n%s", out)
+	}
+	if !strings.Contains(out, "remote_addr") {
+		t.Errorf("SCP log lines missing remote_addr correlation attribute:\n%s", out)
+	}
+	// The negotiated calling AE should appear once the association is established.
+	if !strings.Contains(out, "SCU") {
+		t.Errorf("SCP log lines missing negotiated AE title:\n%s", out)
+	}
+	// The A-ASSOCIATE-AC writer is built fresh during negotiation; its logger
+	// must still be propagated so the accept line reaches the injected logger
+	// rather than slog.Default().
+	if !strings.Contains(out, "A-ASSOCIATE-AC") {
+		t.Errorf("A-ASSOCIATE-AC lines leaked to the default logger instead of the injected one:\n%s", out)
+	}
+}

--- a/services/scp_logger_test.go
+++ b/services/scp_logger_test.go
@@ -74,4 +74,9 @@ func TestSCP_WithLogger_RoutesAndCorrelates(t *testing.T) {
 	if !strings.Contains(out, "A-ASSOCIATE-AC") {
 		t.Errorf("A-ASSOCIATE-AC lines leaked to the default logger instead of the injected one:\n%s", out)
 	}
+	// Presentation-context-accept encode traces must also use the propagated
+	// connection logger rather than slog.Default().
+	if !strings.Contains(out, "accepted transfer syntax") {
+		t.Errorf("presentation-context accept lines leaked to the default logger instead of the injected one:\n%s", out)
+	}
 }

--- a/services/scp_server.go
+++ b/services/scp_server.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net"
 	"time"
 )
@@ -65,10 +64,10 @@ func (s *scp) Start(ctx context.Context) error {
 			if errors.Is(err, net.ErrClosed) {
 				return nil
 			}
-			slog.Error("scp: accept failed", "ERROR", err)
+			s.logger.Error("accept failed", "error", err)
 			return err
 		}
-		slog.Info("scp: new connection", "ADDRESS", conn.RemoteAddr())
+		s.logger.Debug("new connection", "remote_addr", conn.RemoteAddr().String())
 		s.wg.Add(1)
 		go func(c net.Conn) {
 			defer s.wg.Done()

--- a/services/scp_test.go
+++ b/services/scp_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"strconv"
@@ -953,6 +954,8 @@ func (m *cgetStoreSubopMockPDU) SetNetConn(_ net.Conn)                          
 func (m *cgetStoreSubopMockPDU) AddPresContexts(_ network.PresentationContext)                   {}
 func (m *cgetStoreSubopMockPDU) SetOnAssociationRequest(_ func(network.AssociationRequest) bool) {}
 func (m *cgetStoreSubopMockPDU) SetOnRawPDU(_ func(network.RawPDUEvent))                         {}
+func (m *cgetStoreSubopMockPDU) SetLogger(_ *slog.Logger)                                        {}
+func (m *cgetStoreSubopMockPDU) Logger() *slog.Logger                                            { return slog.Default() }
 
 // TestCGetStoreSubop_TranscodesToNegotiatedTS verifies that cgetStoreSubop
 // transcodes the file to the transfer syntax negotiated with the SCU. When the

--- a/services/scu.go
+++ b/services/scu.go
@@ -70,6 +70,10 @@ type SCU interface {
 	// SetTimeout sets the per-connection network timeout in seconds applied to
 	// all associations opened by this SCU. 0 means no timeout (default).
 	SetTimeout(seconds int)
+	// SetLogger sets the structured logger used for this SCU's PDU-level events.
+	// A nil logger resets to slog.Default(). By default the library logs through
+	// slog.Default().
+	SetLogger(logger *slog.Logger)
 	// GetNegotiatedContexts returns the presentation contexts accepted by the
 	// remote SCP after the most recent successful association. Returns nil if no
 	// association has been made yet.
@@ -87,6 +91,7 @@ type scu struct {
 	negotiatedContexts []network.PresentationContextAccept
 	implClassUID       string
 	implVersion        string
+	logger             *slog.Logger
 }
 
 type associationPresentationContext struct {
@@ -110,11 +115,21 @@ func NewSCU(destination *network.Destination, opts ...SCUOption) SCU {
 	d := &scu{
 		destination: destination,
 		priority:    priority.Medium,
+		logger:      slog.Default(),
 	}
 	for _, opt := range opts {
 		opt(d)
 	}
 	return d
+}
+
+// SetLogger sets the structured logger for this SCU. A nil logger resets to
+// slog.Default().
+func (d *scu) SetLogger(logger *slog.Logger) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	d.logger = logger
 }
 
 // newPDUService creates a PDUService, applying a per-SCU implementation class
@@ -123,6 +138,9 @@ func (d *scu) newPDUService() network.PDUService {
 	var opts []network.PDUServiceOption
 	if d.implClassUID != "" || d.implVersion != "" {
 		opts = append(opts, network.WithImplementationClass(d.implClassUID, d.implVersion))
+	}
+	if d.logger != nil {
+		opts = append(opts, network.WithLogger(d.logger))
 	}
 	pdu := network.NewPDUService(opts...)
 	if d.timeout > 0 {
@@ -137,14 +155,14 @@ func (d *scu) EchoSCU(ctx context.Context) error {
 	if err := d.openAssociation(ctx, pdu, sopclass.Verification.UID, []string{}); err != nil {
 		return err
 	}
-	slog.Info("Sending Echo Request")
+	d.logger.Debug("sending C-ECHO request")
 	if err := dimse.CEchoWriteRQ(pdu); err != nil {
 		return err
 	}
 	if err := dimse.CEchoReadRSP(pdu); err != nil {
 		return err
 	}
-	slog.Info("Received Echo Response", "status", "Success")
+	d.logger.Debug("received C-ECHO response", "status", "success")
 	return nil
 }
 
@@ -441,10 +459,10 @@ func (d *scu) openAssociationWithContexts(ctx context.Context, pdu network.PDUSe
 
 	var err error
 	if d.destination.IsTLS {
-		slog.Info("Requesting Association", "host", d.destination.HostName, "port", d.destination.Port, "calledAE", d.destination.CalledAE, "callingAE", d.destination.CallingAE, "tls", true)
+		d.logger.Debug("requesting association", "host", d.destination.HostName, "port", d.destination.Port, "called_ae", d.destination.CalledAE, "calling_ae", d.destination.CallingAE, "tls", true)
 		err = pdu.ConnectTLS(ctx, d.destination.HostName, strconv.Itoa(d.destination.Port), d.destination.TLSConfig)
 	} else {
-		slog.Info("Requesting Association", "host", d.destination.HostName, "port", d.destination.Port, "calledAE", d.destination.CalledAE, "callingAE", d.destination.CallingAE)
+		d.logger.Debug("requesting association", "host", d.destination.HostName, "port", d.destination.Port, "called_ae", d.destination.CalledAE, "calling_ae", d.destination.CallingAE)
 		err = pdu.Connect(ctx, d.destination.HostName, strconv.Itoa(d.destination.Port))
 	}
 	if err == nil {

--- a/services/scu_test.go
+++ b/services/scu_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"sync"
@@ -433,6 +434,8 @@ func (m *storeMockPDU) GetAcceptedPresentationContexts() []network.PresentationC
 }
 func (m *storeMockPDU) SetOnAssociationRequest(_ func(network.AssociationRequest) bool) {}
 func (m *storeMockPDU) SetOnRawPDU(_ func(network.RawPDUEvent))                         {}
+func (m *storeMockPDU) SetLogger(_ *slog.Logger)                                        {}
+func (m *storeMockPDU) Logger() *slog.Logger                                            { return slog.Default() }
 
 // Test_scu_BeginStoreSession_SendsMultipleFilesOnOneAssociation verifies that
 // BeginStoreSession opens exactly one association and that all files in the


### PR DESCRIPTION
## Summary

The library logged exclusively through `slog.Default()`, and `output.Redirect` mutated the global logger — so a consuming app's configured logger was silently replaced, and log lines from concurrent associations interleaved with no way to tell them apart. This PR makes logging injectable, correlatable, and quiet by default.

## Group A — Logger injection + per-association correlation
- `PDUService` gains `WithLogger`/`SetLogger`/`Logger()`. The connection logger propagates to the `AssocRQ`/`AssocAC`/`AssocRJ` sub-structures, including the AC rebuilt during negotiation.
- `SCP` gains `WithLogger`; `SCU` gains `SetLogger`. **Both default to `slog.Default()`** — the library no longer forces a global logger.
- `handleConnection` derives a child logger tagged with `assoc_id` (monotonic) + `remote_addr`, enriched with `calling_ae`/`called_ae` once negotiated. Every line for an association is now correlatable.
- New regression test `scp_logger_test.go` proves the injected logger receives the SCP's lines (incl. the AC line) with the correlation attributes.

## Group B — Quiet levels, snake_case keys, stripped prefixes
- Unified attribute keys to `snake_case` (`ERROR`/`err`→`error`, `ADDRESS`→`remote_addr`, `CallingAE`→`calling_ae`, `MaxPDULength`→`max_pdu_length`, …).
- Stripped `scp:`/`pdu:`/`ASSOC-*:` message prefixes and the `BEGIN/END` banner lines; collapsed the 5 verbose `ASSOC-AC` Info lines into one structured Debug line.
- **Quiet policy:** routine per-association lifecycle → Debug; `association accepted` stays Info; rejections → **Warn**; C-CANCEL → Info; errors stay Error. A running SCP now emits ~1 Info line per association instead of ~8.

## Group C — CLI migrated to slog
- `cmd/io-dicom` no longer imports `log`. A `fatal(msg, args...)` helper (`slog.Error` + `os.Exit(1)`) replaces `log.Fatal*`, and all `log.Printf("INFO/ERROR/WARN…")` calls are now structured `slog`.

## Bonus correctness fix
`-race` surfaced a **pre-existing data race** on `scp.timeout`: `SetTimeout` wrote under the mutex but `newPDUService` read the config fields unlocked. `newPDUService` now snapshots them under `RLock`.

## Sample output
```
INFO  association accepted assoc_id=2 remote_addr=[::1]:51265 calling_ae=SCU called_ae=SCP max_send_pdv=16378
ERROR network error assoc_id=65 remote_addr=[::1]:51263 error="remote error: tls: bad certificate"
```

## Verification
- `go build ./...` / `go vet ./...` — clean
- `staticcheck` — no new findings (only pre-existing ones tracked separately)
- `go test -race ./network/ ./services/ ./dimse/` — pass, no races
- full `go test ./...` — pass
- CLI smoke-tested (structured startup line + `fatal()` error path with non-zero exit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)