### PR TITLE
Remove dead code and apply staticcheck simplifications

### DIFF
--- a/network/a_association_ac.go
+++ b/network/a_association_ac.go
@@ -95,10 +95,6 @@ func (aaac *associationAccept) GetPresContextAccepts() []PresentationContextAcce
 	return aaac.PresContextAccepts
 }
 
-func (aaac *associationAccept) getUserInfo() *userInformation {
-	return aaac.UserInfo
-}
-
 func (aaac *associationAccept) setUserInfo(userInfo *userInformation) {
 	aaac.UserInfo = userInfo
 }

--- a/network/pdu_service.go
+++ b/network/pdu_service.go
@@ -922,10 +922,3 @@ func (pdu *pduService) parseRawVRIntoDCM(DCO media.DICOMObject) bool {
 	pdu.Pdata.Buffer.SetPosition(0)
 	return pdu.Pdata.Buffer.ReadObj(DCO) == nil
 }
-
-func (pdu *pduService) readPDU() error {
-	if pdu.pdulength < 4 {
-		return fmt.Errorf("pdu: malformed PDU length %d (minimum is 4)", pdu.pdulength)
-	}
-	return pdu.buf.ReadFully(pdu.readWriter, int(pdu.pdulength)-4)
-}

--- a/services/scp_handlers.go
+++ b/services/scp_handlers.go
@@ -386,7 +386,7 @@ func (s *scp) runCGetOperation(rw *bufio.ReadWriter, conn net.Conn, pdu network.
 				select {
 				case <-ctx.Done():
 					return
-				case progressCh <- subopProgress{p.Remaining, p.Completed, p.Failed, p.Warnings}:
+				case progressCh <- subopProgress(p):
 				}
 			},
 		)
@@ -498,7 +498,7 @@ func (s *scp) runCMoveOperation(rw *bufio.ReadWriter, conn net.Conn, pdu network
 			select {
 			case <-ctx.Done():
 				return
-			case progressCh <- subopProgress{p.Remaining, p.Completed, p.Failed, p.Warnings}:
+			case progressCh <- subopProgress(p):
 			}
 		})
 		resultCh <- subopResult{


### PR DESCRIPTION
## Summary

Clears all outstanding `staticcheck` findings so the core packages are clean.

## Changes
- **Remove `(*pduService).readPDU`** ([network/pdu_service.go](network/pdu_service.go)) — unused (`U1000`). It was the older, *unbounded* PDU read, fully superseded by `readIncomingPDU`, which carries the `maxIncomingPDULength` DoS bound added in #5. Zero callers anywhere (incl. tests).
- **Remove `(*associationAccept).getUserInfo`** ([network/a_association_ac.go](network/a_association_ac.go)) — unused (`U1000`), zero callers. (`setUserInfo` is retained — it is used.)
- **Convert `subopProgress` struct literals to conversions** (`S1016`) in the C-GET and C-MOVE sub-operation progress paths ([services/scp_handlers.go](services/scp_handlers.go)). `CGetProgress`, `CMoveProgress`, and `subopProgress` have identical field layouts (4× `uint16`, same order), so `subopProgress(p)` is exactly equivalent to the prior field-by-field literal.

No behavior change.

## Verification
- `go build ./...` / `go vet ./...` — clean
- `staticcheck ./network/... ./services/...` — **now clean** (was 4 findings)
- `go test -race ./network/ ./services/ ./dimse/` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)