### PR TITLE
Consolidate the six N-service dispatch handlers

### DIFF
--- a/services/scp.go
+++ b/services/scp.go
@@ -15,8 +15,12 @@ import (
 // NServiceHandler is the common callback signature for the DICOM normalized
 // (N-) services: N-EVENT-REPORT, N-GET, N-SET, N-ACTION, N-CREATE, and
 // N-DELETE. It receives the request command object and any request dataset, and
-// returns the DIMSE status plus an optional response dataset. It is a type alias
-// so existing code passing plain function literals continues to compile.
+// returns the DIMSE status plus an optional response dataset.
+//
+// It is deliberately a type alias rather than a defined type: this keeps the
+// exported SCP interface method signatures byte-for-byte identical to the
+// previous func(...) types, so external implementations of SCP and any
+// type-identity checks continue to satisfy the interface without change.
 type NServiceHandler = func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject)
 
 // SCP - Interface to scp

--- a/services/scp.go
+++ b/services/scp.go
@@ -12,6 +12,13 @@ import (
 	"github.com/innovative-io/io-dicom/network"
 )
 
+// NServiceHandler is the common callback signature for the DICOM normalized
+// (N-) services: N-EVENT-REPORT, N-GET, N-SET, N-ACTION, N-CREATE, and
+// N-DELETE. It receives the request command object and any request dataset, and
+// returns the DIMSE status plus an optional response dataset. It is a type alias
+// so existing code passing plain function literals continues to compile.
+type NServiceHandler = func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject)
+
 // SCP - Interface to scp
 type SCP interface {
 	// Start begins accepting connections and blocks until the listener is
@@ -24,12 +31,12 @@ type SCP interface {
 	OnCGetRequest(f CGetHandler)
 	OnCMoveRequest(f CMoveHandler)
 	OnCStoreRequest(f func(ctx context.Context, request network.AssociationRequest, data media.DICOMObject) uint16)
-	OnNEventReportRequest(f func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject))
-	OnNGetRequest(f func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject))
-	OnNSetRequest(f func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject))
-	OnNActionRequest(f func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject))
-	OnNCreateRequest(f func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject))
-	OnNDeleteRequest(f func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject))
+	OnNEventReportRequest(f NServiceHandler)
+	OnNGetRequest(f NServiceHandler)
+	OnNSetRequest(f NServiceHandler)
+	OnNActionRequest(f NServiceHandler)
+	OnNCreateRequest(f NServiceHandler)
+	OnNDeleteRequest(f NServiceHandler)
 	// OnCCancelRequest registers an optional callback invoked for incoming
 	// C-CANCEL-RQ message IDs.
 	OnCCancelRequest(f func(request network.AssociationRequest, messageID uint16))
@@ -103,12 +110,12 @@ type scp struct {
 	listener              net.Listener
 	wg                    sync.WaitGroup
 	mu                    sync.RWMutex
-	onNEventReportRequest func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject)
-	onNGetRequest         func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject)
-	onNSetRequest         func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject)
-	onNActionRequest      func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject)
-	onNCreateRequest      func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject)
-	onNDeleteRequest      func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject)
+	onNEventReportRequest NServiceHandler
+	onNGetRequest         NServiceHandler
+	onNSetRequest         NServiceHandler
+	onNActionRequest      NServiceHandler
+	onNCreateRequest      NServiceHandler
+	onNDeleteRequest      NServiceHandler
 
 	onAssociationRequest func(request network.AssociationRequest) bool
 	onCFindRequest       CFindHandler

--- a/services/scp_association.go
+++ b/services/scp_association.go
@@ -103,6 +103,35 @@ func (s *scp) pollCommand(conn net.Conn, pdu network.PDUService) (media.DICOMObj
 	return dco, nil
 }
 
+// handleNRequest services one DICOM normalized (N-) request: it reads the
+// optional request dataset, dispatches to handler (or replies
+// FailureSOPClassNotSupported when none is registered), and writes the response
+// identified by responseCmd. label is the human-readable service name used in
+// log messages (e.g. "N-Get"). It returns true when the caller must terminate
+// the association because an unrecoverable read/write error was logged.
+func (s *scp) handleNRequest(ctx context.Context, pdu network.PDUService, dco media.DICOMObject, label string, responseCmd uint16, handler NServiceHandler) (stop bool) {
+	var nData media.DICOMObject
+	if dco.GetUint16(tags.CommandDataSetType) != dicomcommand.DataSetNone {
+		d, err := pdu.NextPDU()
+		if err != nil {
+			pdu.Logger().Error(label+" failed to read request dataset", "error", err)
+			return true
+		}
+		nData = d
+	}
+
+	status := dicomstatus.FailureSOPClassNotSupported
+	resp := media.NewEmptyDCMObj()
+	if handler != nil {
+		status, resp = handler(ctx, pdu.GetAAssociationRQ(), dco, nData)
+	}
+	if err := dimse.NWriteRSP(pdu, dco, responseCmd, status, resp); err != nil {
+		pdu.Logger().Error(label+" failed to write response", "error", err)
+		return true
+	}
+	return false
+}
+
 func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 	rw := bufio.NewReadWriter(
 		bufio.NewReaderSize(conn, s.bufSize),
@@ -315,134 +344,50 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			}
 
 		case dicomcommand.NEventReportRequest:
-			var nData media.DICOMObject
-			if dco.GetUint16(tags.CommandDataSetType) != dicomcommand.DataSetNone {
-				nData, err = pdu.NextPDU()
-				if err != nil {
-					pdu.Logger().Error("N-Event-Report failed to read request dataset", "error", err)
-					return
-				}
-			}
 			s.mu.RLock()
 			h := s.onNEventReportRequest
 			s.mu.RUnlock()
-			status := dicomstatus.FailureSOPClassNotSupported
-			resp := media.NewEmptyDCMObj()
-			if h != nil {
-				status, resp = h(ctx, pdu.GetAAssociationRQ(), dco, nData)
-			}
-			if err := dimse.NWriteRSP(pdu, dco, dicomcommand.NEventReportResponse, status, resp); err != nil {
-				pdu.Logger().Error("N-Event-Report failed to write response", "error", err)
+			if s.handleNRequest(ctx, pdu, dco, "N-Event-Report", dicomcommand.NEventReportResponse, h) {
 				return
 			}
 
 		case dicomcommand.NGetRequest:
-			var nData media.DICOMObject
-			if dco.GetUint16(tags.CommandDataSetType) != dicomcommand.DataSetNone {
-				nData, err = pdu.NextPDU()
-				if err != nil {
-					pdu.Logger().Error("N-Get failed to read request dataset", "error", err)
-					return
-				}
-			}
 			s.mu.RLock()
 			h := s.onNGetRequest
 			s.mu.RUnlock()
-			status := dicomstatus.FailureSOPClassNotSupported
-			resp := media.NewEmptyDCMObj()
-			if h != nil {
-				status, resp = h(ctx, pdu.GetAAssociationRQ(), dco, nData)
-			}
-			if err := dimse.NWriteRSP(pdu, dco, dicomcommand.NGetResponse, status, resp); err != nil {
-				pdu.Logger().Error("N-Get failed to write response", "error", err)
+			if s.handleNRequest(ctx, pdu, dco, "N-Get", dicomcommand.NGetResponse, h) {
 				return
 			}
 
 		case dicomcommand.NSetRequest:
-			var nData media.DICOMObject
-			if dco.GetUint16(tags.CommandDataSetType) != dicomcommand.DataSetNone {
-				nData, err = pdu.NextPDU()
-				if err != nil {
-					pdu.Logger().Error("N-Set failed to read request dataset", "error", err)
-					return
-				}
-			}
 			s.mu.RLock()
 			h := s.onNSetRequest
 			s.mu.RUnlock()
-			status := dicomstatus.FailureSOPClassNotSupported
-			resp := media.NewEmptyDCMObj()
-			if h != nil {
-				status, resp = h(ctx, pdu.GetAAssociationRQ(), dco, nData)
-			}
-			if err := dimse.NWriteRSP(pdu, dco, dicomcommand.NSetResponse, status, resp); err != nil {
-				pdu.Logger().Error("N-Set failed to write response", "error", err)
+			if s.handleNRequest(ctx, pdu, dco, "N-Set", dicomcommand.NSetResponse, h) {
 				return
 			}
 
 		case dicomcommand.NActionRequest:
-			var nData media.DICOMObject
-			if dco.GetUint16(tags.CommandDataSetType) != dicomcommand.DataSetNone {
-				nData, err = pdu.NextPDU()
-				if err != nil {
-					pdu.Logger().Error("N-Action failed to read request dataset", "error", err)
-					return
-				}
-			}
 			s.mu.RLock()
 			h := s.onNActionRequest
 			s.mu.RUnlock()
-			status := dicomstatus.FailureSOPClassNotSupported
-			resp := media.NewEmptyDCMObj()
-			if h != nil {
-				status, resp = h(ctx, pdu.GetAAssociationRQ(), dco, nData)
-			}
-			if err := dimse.NWriteRSP(pdu, dco, dicomcommand.NActionResponse, status, resp); err != nil {
-				pdu.Logger().Error("N-Action failed to write response", "error", err)
+			if s.handleNRequest(ctx, pdu, dco, "N-Action", dicomcommand.NActionResponse, h) {
 				return
 			}
 
 		case dicomcommand.NCreateRequest:
-			var nData media.DICOMObject
-			if dco.GetUint16(tags.CommandDataSetType) != dicomcommand.DataSetNone {
-				nData, err = pdu.NextPDU()
-				if err != nil {
-					pdu.Logger().Error("N-Create failed to read request dataset", "error", err)
-					return
-				}
-			}
 			s.mu.RLock()
 			h := s.onNCreateRequest
 			s.mu.RUnlock()
-			status := dicomstatus.FailureSOPClassNotSupported
-			resp := media.NewEmptyDCMObj()
-			if h != nil {
-				status, resp = h(ctx, pdu.GetAAssociationRQ(), dco, nData)
-			}
-			if err := dimse.NWriteRSP(pdu, dco, dicomcommand.NCreateResponse, status, resp); err != nil {
-				pdu.Logger().Error("N-Create failed to write response", "error", err)
+			if s.handleNRequest(ctx, pdu, dco, "N-Create", dicomcommand.NCreateResponse, h) {
 				return
 			}
 
 		case dicomcommand.NDeleteRequest:
-			var nData media.DICOMObject
-			if dco.GetUint16(tags.CommandDataSetType) != dicomcommand.DataSetNone {
-				nData, err = pdu.NextPDU()
-				if err != nil {
-					pdu.Logger().Error("N-Delete failed to read request dataset", "error", err)
-					return
-				}
-			}
 			s.mu.RLock()
 			h := s.onNDeleteRequest
 			s.mu.RUnlock()
-			status := dicomstatus.FailureSOPClassNotSupported
-			resp := media.NewEmptyDCMObj()
-			if h != nil {
-				status, resp = h(ctx, pdu.GetAAssociationRQ(), dco, nData)
-			}
-			if err := dimse.NWriteRSP(pdu, dco, dicomcommand.NDeleteResponse, status, resp); err != nil {
-				pdu.Logger().Error("N-Delete failed to write response", "error", err)
+			if s.handleNRequest(ctx, pdu, dco, "N-Delete", dicomcommand.NDeleteResponse, h) {
 				return
 			}
 

--- a/services/scp_handlers.go
+++ b/services/scp_handlers.go
@@ -544,37 +544,37 @@ func (s *scp) OnCStoreRequest(f func(ctx context.Context, request network.Associ
 	s.onCStoreRequest = f
 }
 
-func (s *scp) OnNEventReportRequest(f func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject)) {
+func (s *scp) OnNEventReportRequest(f NServiceHandler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onNEventReportRequest = f
 }
 
-func (s *scp) OnNGetRequest(f func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject)) {
+func (s *scp) OnNGetRequest(f NServiceHandler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onNGetRequest = f
 }
 
-func (s *scp) OnNSetRequest(f func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject)) {
+func (s *scp) OnNSetRequest(f NServiceHandler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onNSetRequest = f
 }
 
-func (s *scp) OnNActionRequest(f func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject)) {
+func (s *scp) OnNActionRequest(f NServiceHandler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onNActionRequest = f
 }
 
-func (s *scp) OnNCreateRequest(f func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject)) {
+func (s *scp) OnNCreateRequest(f NServiceHandler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onNCreateRequest = f
 }
 
-func (s *scp) OnNDeleteRequest(f func(ctx context.Context, request network.AssociationRequest, command media.DICOMObject, data media.DICOMObject) (status uint16, responseData media.DICOMObject)) {
+func (s *scp) OnNDeleteRequest(f NServiceHandler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onNDeleteRequest = f

--- a/services/scp_nservice_test.go
+++ b/services/scp_nservice_test.go
@@ -1,0 +1,153 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/dictionary/tags"
+	"github.com/innovative-io/io-dicom/media"
+	"github.com/innovative-io/io-dicom/network"
+	"github.com/innovative-io/io-dicom/network/dicomcommand"
+	"github.com/innovative-io/io-dicom/network/dicomstatus"
+)
+
+// nServiceMockPDU embeds the C-GET sub-op mock (which already satisfies the full
+// network.PDUService interface) and overrides only the read/write paths that
+// handleNRequest exercises.
+type nServiceMockPDU struct {
+	cgetStoreSubopMockPDU
+	dataset    media.DICOMObject // returned by NextPDU when a request dataset is read
+	nextErr    error             // error returned by NextPDU
+	nextCalled bool
+	respCmd    media.DICOMObject // captured N-service response command
+}
+
+func (m *nServiceMockPDU) NextPDU() (media.DICOMObject, error) {
+	m.nextCalled = true
+	return m.dataset, m.nextErr
+}
+
+func (m *nServiceMockPDU) Write(dco media.DICOMObject, itemType byte) error {
+	if itemType == network.PDVCommand {
+		m.respCmd = dco
+	}
+	return nil
+}
+
+// nServiceRequest builds a minimal N-service request command carrying the fields
+// NWriteRSP requires (a SOP Class UID and a message ID) plus the dataset-type
+// flag that controls whether handleNRequest reads a request dataset.
+func nServiceRequest(dataSetType uint16) media.DICOMObject {
+	dco := media.NewEmptyDCMObj()
+	dco.Write(tags.AffectedSOPClassUID, "1.2.840.10008.5.1.4.1.1.4")
+	dco.Write(tags.MessageID, uint16(7))
+	dco.Write(tags.CommandDataSetType, dataSetType)
+	return dco
+}
+
+// TestHandleNRequest_DispatchesAndWritesResponse verifies the common N-service
+// path: the registered handler is invoked, its status flows into the response,
+// and the response carries the requested command field.
+func TestHandleNRequest_DispatchesAndWritesResponse(t *testing.T) {
+	s := NewSCP(0).(*scp)
+	mock := &nServiceMockPDU{}
+	dco := nServiceRequest(dicomcommand.DataSetNone)
+
+	var gotCmd media.DICOMObject
+	handler := func(_ context.Context, _ network.AssociationRequest, command media.DICOMObject, _ media.DICOMObject) (uint16, media.DICOMObject) {
+		gotCmd = command
+		return dicomstatus.Success, media.NewEmptyDCMObj()
+	}
+
+	if stop := s.handleNRequest(context.Background(), mock, dco, "N-Get", dicomcommand.NGetResponse, handler); stop {
+		t.Fatal("handleNRequest returned stop=true on the success path")
+	}
+	if mock.nextCalled {
+		t.Error("NextPDU was called even though CommandDataSetType is DataSetNone")
+	}
+	if gotCmd == nil {
+		t.Error("handler did not receive the request command object")
+	}
+	if mock.respCmd == nil {
+		t.Fatal("no response command was written")
+	}
+	if got := mock.respCmd.GetUint16(tags.Status); got != dicomstatus.Success {
+		t.Errorf("response status = 0x%04X, want Success (0x0000)", got)
+	}
+	if got := mock.respCmd.GetUint16(tags.CommandField); got != dicomcommand.NGetResponse {
+		t.Errorf("response command field = 0x%04X, want NGetResponse (0x%04X)", got, dicomcommand.NGetResponse)
+	}
+}
+
+// TestHandleNRequest_NoHandlerReturnsUnsupported verifies that, with no handler
+// registered, the SCP replies with FailureSOPClassNotSupported.
+func TestHandleNRequest_NoHandlerReturnsUnsupported(t *testing.T) {
+	s := NewSCP(0).(*scp)
+	mock := &nServiceMockPDU{}
+	dco := nServiceRequest(dicomcommand.DataSetNone)
+
+	if stop := s.handleNRequest(context.Background(), mock, dco, "N-Get", dicomcommand.NGetResponse, nil); stop {
+		t.Fatal("handleNRequest returned stop=true with no handler")
+	}
+	if mock.respCmd == nil {
+		t.Fatal("no response command was written")
+	}
+	if got := mock.respCmd.GetUint16(tags.Status); got != dicomstatus.FailureSOPClassNotSupported {
+		t.Errorf("response status = 0x%04X, want FailureSOPClassNotSupported (0x%04X)", got, dicomstatus.FailureSOPClassNotSupported)
+	}
+}
+
+// TestHandleNRequest_PassesDataset verifies the request dataset is read (when
+// CommandDataSetType is DataSetPresent) and handed to the handler.
+func TestHandleNRequest_PassesDataset(t *testing.T) {
+	s := NewSCP(0).(*scp)
+	ds := media.NewEmptyDCMObj()
+	ds.Write(tags.PatientID, "PID-1")
+	mock := &nServiceMockPDU{dataset: ds}
+	dco := nServiceRequest(dicomcommand.DataSetPresent)
+
+	var gotData media.DICOMObject
+	handler := func(_ context.Context, _ network.AssociationRequest, _ media.DICOMObject, data media.DICOMObject) (uint16, media.DICOMObject) {
+		gotData = data
+		return dicomstatus.Success, nil
+	}
+
+	if stop := s.handleNRequest(context.Background(), mock, dco, "N-Set", dicomcommand.NSetResponse, handler); stop {
+		t.Fatal("handleNRequest returned stop=true on the success path")
+	}
+	if !mock.nextCalled {
+		t.Error("NextPDU was not called for DataSetPresent")
+	}
+	if gotData == nil || gotData.GetString(tags.PatientID) != "PID-1" {
+		t.Errorf("handler did not receive the request dataset: %v", gotData)
+	}
+}
+
+// TestHandleNRequest_DatasetReadErrorStops verifies that a failed dataset read
+// terminates the association (stop=true), the handler is not invoked, and no
+// response is written.
+func TestHandleNRequest_DatasetReadErrorStops(t *testing.T) {
+	s := NewSCP(0).(*scp)
+	mock := &nServiceMockPDU{nextErr: errors.New("read failed")}
+	dco := nServiceRequest(dicomcommand.DataSetPresent)
+
+	called := false
+	handler := func(_ context.Context, _ network.AssociationRequest, _ media.DICOMObject, _ media.DICOMObject) (uint16, media.DICOMObject) {
+		called = true
+		return dicomstatus.Success, nil
+	}
+
+	if stop := s.handleNRequest(context.Background(), mock, dco, "N-Get", dicomcommand.NGetResponse, handler); !stop {
+		t.Fatal("handleNRequest returned stop=false on a dataset read error")
+	}
+	if !mock.nextCalled {
+		t.Error("NextPDU was not called for DataSetPresent")
+	}
+	if called {
+		t.Error("handler was invoked despite the dataset read failing")
+	}
+	if mock.respCmd != nil {
+		t.Error("a response was written despite the dataset read failing")
+	}
+}


### PR DESCRIPTION
## Summary

The DICOM normalized-service dispatch in `handleConnection` was six near-identical ~22-line `case` blocks (N-EVENT-REPORT / N-GET / N-SET / N-ACTION / N-CREATE / N-DELETE) differing only in three values: the handler field, the response command, and the log label. The shared handler signature was also spelled out **18 times** across the struct fields, setters, and the `SCP` interface.

## Changes
- **`NServiceHandler` type alias** for the common callback signature, applied to the 6 struct fields, 6 `OnN*` setters, and 6 interface declarations. It's a **type alias**, so existing code passing plain function literals compiles unchanged — no public API break.
- **Extract `handleNRequest`** ([services/scp_association.go](services/scp_association.go)): reads the optional request dataset, dispatches to the handler (or replies `FailureSOPClassNotSupported` when none is registered), writes the response, and returns whether the association should terminate. Each dispatch case is now ~6 lines.

Net **~48 fewer lines** of production code, behavior-preserving.

## Tests
The SCP-level N-service dispatch previously had **no direct test**. Adds `scp_nservice_test.go` covering:
- handler dispatch → status + response command field,
- no-handler default (`FailureSOPClassNotSupported`),
- request-dataset pass-through (`DataSetPresent`),
- dataset-read-error termination (`stop=true`, handler not called, no response written).

## Verification
- `go build ./...` / `go vet ./...` — clean
- `staticcheck` — no new findings
- `go test -race ./services/ ./network/ ./dimse/` — pass

> Note: independent of the still-open dead-code cleanup ([#7](https://github.com/innovative-io/io-dicom/pull/7)); they touch different regions of `scp_handlers.go` and merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)