### PR TITLE
Fuzz targets + vet/staticcheck/race CI pipeline (§2/§3b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+# This is the lightweight, pure-Go pipeline: vet, staticcheck, race tests, and a
+# short fuzz smoke run, all without native codec dependencies (the cgo-only
+# bridges are excluded by build constraints). Native codec coverage lives in
+# codec-tagged-tests.yml.
+jobs:
+  vet-lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: staticcheck
+        run: go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test (race detector)
+        run: go test -race ./...
+
+  fuzz-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # Actively explore for a short window on top of the committed seed corpus.
+      # Any new crasher is written under testdata/fuzz and fails the job.
+      - name: Fuzz DICOM object parser
+        run: go test -run=^$ -fuzz=FuzzNewDCMObjFromBytes -fuzztime=60s ./media
+
+      - name: Fuzz PDU reader
+        run: go test -run=^$ -fuzz=FuzzReadIncomingPDU -fuzztime=60s ./network
+
+      - name: Fuzz P-DATA-TF decoder
+        run: go test -run=^$ -fuzz=FuzzPDataTFReadDynamic -fuzztime=60s ./network

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,15 @@
 
 NATIVE_CODEC_TAGS := libjpeg charls openjpeg libjxl openjph ffmpeg st2110
 
-# Pinned via go run so contributors and CI need no separate install step.
+# Run via `go run` so contributors and CI need no separate install step. Uses
+# @latest (intentionally not pinned) to track staticcheck releases and stay
+# compatible with the newest Go toolchain.
 STATICCHECK := go run honnef.co/go/tools/cmd/staticcheck@latest
 
-# Active fuzz time per target for `make fuzz`. The committed seed corpus
-# (including regression crashers under testdata/fuzz) always runs via `go test`.
+# Active fuzz time per target for `make fuzz`. The in-code seed corpus (the f.Add
+# inputs, including the empty-UID regression) always runs via `go test`. Note
+# testdata/ is gitignored, so Go's testdata/fuzz crasher corpus stays local and
+# untracked.
 FUZZTIME ?= 30s
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,22 @@
-.PHONY: help test test-tags deps-from-source build-native install install-native transfer-syntax-matrix contract-check
+.PHONY: help test test-tags vet lint race fuzz deps-from-source build-native install install-native transfer-syntax-matrix contract-check
 
 NATIVE_CODEC_TAGS := libjpeg charls openjpeg libjxl openjph ffmpeg st2110
+
+# Pinned via go run so contributors and CI need no separate install step.
+STATICCHECK := go run honnef.co/go/tools/cmd/staticcheck@latest
+
+# Active fuzz time per target for `make fuzz`. The committed seed corpus
+# (including regression crashers under testdata/fuzz) always runs via `go test`.
+FUZZTIME ?= 30s
 
 help:
 	@echo "Available targets:"
 	@echo "  make test               # Run go test ./..."
 	@echo "  make test-tags          # Run all tagged codec backend tests"
+	@echo "  make vet                # Run go vet ./..."
+	@echo "  make lint               # Run staticcheck ./..."
+	@echo "  make race               # Run go test -race ./..."
+	@echo "  make fuzz               # Run each fuzz target for FUZZTIME (default 30s)"
 	@echo "  make deps-from-source   # Download and compile codec dependencies from source"
 	@echo "  make build-native       # Build source deps, compile with native codec tags, run contract checks"
 	@echo "  make install            # Install io-dicom CLI (pure Go) to GOPATH/bin"
@@ -15,6 +26,20 @@ help:
 
 test:
 	go test ./...
+
+vet:
+	go vet ./...
+
+lint:
+	$(STATICCHECK) ./...
+
+race:
+	go test -race ./...
+
+fuzz:
+	go test -run=^$$ -fuzz=FuzzNewDCMObjFromBytes -fuzztime=$(FUZZTIME) ./media
+	go test -run=^$$ -fuzz=FuzzReadIncomingPDU -fuzztime=$(FUZZTIME) ./network
+	go test -run=^$$ -fuzz=FuzzPDataTFReadDynamic -fuzztime=$(FUZZTIME) ./network
 
 test-tags:
 	./scripts/test_codec_tags.sh

--- a/codecs/internal/ffmpegbridge/ffmpeg_bridge.c
+++ b/codecs/internal/ffmpegbridge/ffmpeg_bridge.c
@@ -1,3 +1,5 @@
+//go:build cgo && (ffmpeg || st2110)
+
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavutil/avutil.h>

--- a/codecs/internal/ffmpegbridge/ffmpegbridge.go
+++ b/codecs/internal/ffmpegbridge/ffmpegbridge.go
@@ -1,3 +1,5 @@
+//go:build cgo && (ffmpeg || st2110)
+
 package ffmpegbridge
 
 /*

--- a/codecs/jpeg2000/sample_codec_test.go
+++ b/codecs/jpeg2000/sample_codec_test.go
@@ -63,7 +63,7 @@ func extractFirstDICOMEncapsulatedFrame(t *testing.T, dcmData []byte) []byte {
 	}
 	// If BOT is non-empty, next item is the frame; if BOT is empty, next is also the frame.
 	frame := readItem()
-	if frame == nil || len(frame) == 0 {
+	if len(frame) == 0 {
 		t.Fatal("could not read frame item from pixel data sequence")
 	}
 	return frame

--- a/dictionary/transfersyntax/uids.go
+++ b/dictionary/transfersyntax/uids.go
@@ -80,12 +80,17 @@ func GetTransferSyntaxFromUID(uid string) *TransferSyntax {
 			return ts
 		}
 	}
-	// Retry without a trailing byte to tolerate a UID that still carries an
-	// odd-length null/space pad byte the caller did not trim. Guard len > 0:
-	// an empty UID (e.g. from malformed/truncated file meta) must not slice to
-	// a negative bound.
-	if len(uid) > 0 {
-		trimmed := uid[:len(uid)-1]
+	// Retry without the trailing byte to recover from a known class of malformed
+	// UIDs: encoders that padded an odd-length UID with an extra character
+	// instead of trimming it. This deliberately handles non-standard padding too
+	// — testdata/test2-2.dcm carries "1.2.840.10008.1.2.10" (a stray '0' digit)
+	// that must resolve to "1.2.840.10008.1.2.1". A value is only returned when
+	// the trimmed string exactly matches a registered transfer syntax, so an
+	// unknown UID falls through to nil rather than being silently rewritten.
+	// Guard len > 0 so an empty UID (malformed or truncated file meta) is never
+	// sliced to a negative bound.
+	if n := len(uid); n > 0 {
+		trimmed := uid[:n-1]
 		for _, ts := range transferSyntaxes {
 			if ts.UID == trimmed {
 				return ts

--- a/dictionary/transfersyntax/uids.go
+++ b/dictionary/transfersyntax/uids.go
@@ -80,11 +80,16 @@ func GetTransferSyntaxFromUID(uid string) *TransferSyntax {
 			return ts
 		}
 	}
-	// Extra loop to fix old bug
-	uid = string([]rune(uid)[:len(uid)-1])
-	for _, ts := range transferSyntaxes {
-		if ts.UID == uid {
-			return ts
+	// Retry without a trailing byte to tolerate a UID that still carries an
+	// odd-length null/space pad byte the caller did not trim. Guard len > 0:
+	// an empty UID (e.g. from malformed/truncated file meta) must not slice to
+	// a negative bound.
+	if len(uid) > 0 {
+		trimmed := uid[:len(uid)-1]
+		for _, ts := range transferSyntaxes {
+			if ts.UID == trimmed {
+				return ts
+			}
 		}
 	}
 	return nil

--- a/media/dicom_buffer.go
+++ b/media/dicom_buffer.go
@@ -403,14 +403,6 @@ func (buf *DICOMBuffer) GetAllBytes() []byte {
 	return buf.GetData()
 }
 
-func (buf *DICOMBuffer) readString(length int) string {
-	temp, err := buf.Read(length)
-	if err != nil {
-		return ""
-	}
-	return string(temp)
-}
-
 // readVR reads the 2-byte VR field from the stream and returns an interned
 // string constant, avoiding the heap allocation that string() conversion
 // would otherwise cause on every explicit-VR tag.

--- a/media/fuzz_test.go
+++ b/media/fuzz_test.go
@@ -1,0 +1,51 @@
+package media
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// FuzzNewDCMObjFromBytes exercises the full DICOM parse path (file meta + dataset)
+// against arbitrary bytes. The only contract under fuzzing is that parsing
+// untrusted input must never panic or hang — a returned error is an acceptable
+// outcome. Run with: go test -run=^$ -fuzz=FuzzNewDCMObjFromBytes ./media
+func FuzzNewDCMObjFromBytes(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte("DICM"))
+
+	// 128-byte preamble + "DICM" magic with no following meta — a common
+	// truncation the parser must reject cleanly.
+	preamble := make([]byte, 132)
+	copy(preamble[128:], "DICM")
+	f.Add(preamble)
+
+	// Regression (found by this fuzzer): a file-meta TransferSyntaxUID
+	// (0002,0010) carrying an empty value drove GetTransferSyntaxFromUID("")
+	// into a negative slice bound. Kept as an explicit seed because the repo
+	// gitignores testdata/, so Go's testdata/fuzz crasher corpus is not tracked.
+	f.Add([]byte(strings.Repeat("0", 128) + "DICM\x02\x00\x10\x0000\x00\x00"))
+
+	// Seed from a real DICOM file when present so the fuzzer starts from valid
+	// structure and mutates outward.
+	if data, err := os.ReadFile("../testdata/test.dcm"); err == nil {
+		f.Add(data)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		obj, err := NewDCMObjFromBytes(data)
+		if err != nil || obj == nil {
+			return
+		}
+		// Exercise read accessors on whatever was parsed to surface latent
+		// panics in tag/index handling.
+		_ = obj.TagCount()
+		for i := 0; i < obj.TagCount(); i++ {
+			tag := obj.GetTagAt(i)
+			if tag == nil {
+				continue
+			}
+			_ = tag.GetString()
+		}
+	})
+}

--- a/media/fuzz_test.go
+++ b/media/fuzz_test.go
@@ -39,8 +39,8 @@ func FuzzNewDCMObjFromBytes(f *testing.F) {
 		}
 		// Exercise read accessors on whatever was parsed to surface latent
 		// panics in tag/index handling.
-		_ = obj.TagCount()
-		for i := 0; i < obj.TagCount(); i++ {
+		n := obj.TagCount()
+		for i := 0; i < n; i++ {
 			tag := obj.GetTagAt(i)
 			if tag == nil {
 				continue

--- a/network/fuzz_test.go
+++ b/network/fuzz_test.go
@@ -1,0 +1,50 @@
+package network
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/media"
+)
+
+// FuzzReadIncomingPDU drives the raw PDU reader with arbitrary bytes. The reader
+// parses an attacker-controlled 32-bit length and allocates a receive buffer, so
+// the contract is: never panic and never allocate beyond maxIncomingPDULength.
+// Run with: go test -run=^$ -fuzz=FuzzReadIncomingPDU ./network
+func FuzzReadIncomingPDU(f *testing.F) {
+	f.Add([]byte{})
+	// Well-formed-ish small PDU header (type, reserved, length=6) + 6 body bytes.
+	f.Add([]byte{0x04, 0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02})
+	// Header advertising a near-4 GiB length — must be rejected before allocating.
+	f.Add([]byte{0x01, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		pdu := NewPDUService().(*pduService)
+		r := bufio.NewReader(bytes.NewReader(data))
+		w := bufio.NewWriter(io.Discard)
+		pdu.SetConn(bufio.NewReadWriter(r, w))
+		// A returned error is fine; a panic or unbounded allocation is not.
+		_, _, _ = pdu.readIncomingPDU()
+	})
+}
+
+// FuzzPDataTFReadDynamic targets the P-DATA-TF / PDV decode path, where malformed
+// PDV length fields previously underflowed uint32 arithmetic. The contract is:
+// never panic and never loop unboundedly on arbitrary input.
+// Run with: go test -run=^$ -fuzz=FuzzPDataTFReadDynamic ./network
+func FuzzPDataTFReadDynamic(f *testing.F) {
+	f.Add([]byte{})
+	// Reserved1 + Length(10 BE) + pdv.Length(0xFFFFFFFF) + PCID + MsgHeader.
+	f.Add([]byte{0x00, 0x00, 0x00, 0x00, 0x0A, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x02})
+	// A small, structurally plausible PDV.
+	f.Add([]byte{0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x04, 0x01, 0x03, 0xAA, 0xBB})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		pd := &PresentationDataTransfer{Buffer: media.NewDICOMBuffer()}
+		buf := media.NewDICOMBufferFromBytes(data)
+		buf.SetBigEndian(true)
+		_ = pd.ReadDynamic(buf)
+	})
+}


### PR DESCRIPTION
## Summary

Implements the remaining roadmap items **§2** (fuzz the parser/PDU reader) and **§3b** (wire `vet`/`staticcheck`/`-race` into CI). Adds three fuzz targets, a lightweight pure-Go CI workflow, and Makefile targets — and fixes a real parser crash the fuzzer found immediately.

## What's added
- **Fuzz targets**
  - `FuzzNewDCMObjFromBytes` — full DICOM parse (file meta + dataset).
  - `FuzzReadIncomingPDU` — the raw PDU length/allocation path (the §1 DoS cap).
  - `FuzzPDataTFReadDynamic` — the P-DATA-TF / PDV decode path (the §1 underflow guard).
- **`.github/workflows/ci.yml`** — `go vet`, `staticcheck`, build, `go test -race`, plus a short active fuzz-smoke job. Pure-Go, no native codec deps; complements the existing `codec-tagged-tests.yml`.
- **Makefile** — `vet`, `lint` (staticcheck via `go run`), `race`, `fuzz` targets.

## Bugs fixed while wiring this up
- **🐛 Parser crash (found by the fuzzer):** `transfersyntax.GetTransferSyntaxFromUID` panicked with `slice bounds out of range [:-1]` on an **empty UID** — i.e. a malformed/truncated file-meta `TransferSyntaxUID (0002,0010)`. Any peer or file could trigger it. Guarded with `len > 0` and simplified to byte slicing. Captured as an explicit `f.Add` **regression seed** (the repo gitignores `testdata/`, so Go's `testdata/fuzz` crasher corpus isn't tracked).
- **CI build blocker:** `ffmpegbridge` (cgo-only, no fallback) had **no build constraint**, so `go test ./...` tried to compile it without `libav` and failed. Added `//go:build cgo && (ffmpeg || st2110)` matching its only importers — the pure-Go pipeline now skips it cleanly. (Also makes `make test` robust on machines without ffmpeg.)
- **Pre-existing `staticcheck` findings** cleared so CI is green from day one: unused `(*DICOMBuffer).readString` (U1000) and an `S1009` nil-check in a jpeg2000 test.

## Verification
- `go build ./...` / `go vet ./...` — clean
- `staticcheck ./...` — clean (module-wide)
- `go test -race ./...` — pass
- All three fuzzers run millions of execs with no crashes; the regression seed reproduces (and now passes) the fixed panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)