### PR TITLE
Dedupe C-GET event loop (§ C-Get/C-Move) and cut P-DATA-TF allocations (§4)

### DIFF
--- a/network/p_data_tf.go
+++ b/network/p_data_tf.go
@@ -2,11 +2,28 @@ package network
 
 import (
 	"bufio"
+	"encoding/binary"
 	"fmt"
 
 	"github.com/innovative-io/io-dicom/media"
 	"github.com/innovative-io/io-dicom/network/internal/pdutype"
 )
+
+// writePDVHeader writes the 12-byte P-DATA-TF + PDV header (big-endian) straight
+// to rw. Building it on the stack avoids allocating a fresh DICOMBuffer for every
+// PDV — the previous approach allocated a 4 KiB buffer per fragment, which adds
+// up across the many fragments of a large pixel-data transfer.
+func writePDVHeader(rw *bufio.ReadWriter, itemType, reserved1 byte, pduLength, pdvLength uint32, pcid, msgHeader byte) error {
+	var hdr [12]byte
+	hdr[0] = itemType
+	hdr[1] = reserved1
+	binary.BigEndian.PutUint32(hdr[2:6], pduLength)
+	binary.BigEndian.PutUint32(hdr[6:10], pdvLength)
+	hdr[10] = pcid
+	hdr[11] = msgHeader
+	_, err := rw.Write(hdr[:])
+	return err
+}
 
 // PresentationDataTransfer - PresentationDataTransfer
 type PresentationDataTransfer struct {
@@ -102,15 +119,7 @@ func (pd *PresentationDataTransfer) Write(rw *bufio.ReadWriter) error {
 		pd.Length = pd.pdv.Length + 4
 		pd.ItemType = pdutype.PDUDataTransfer
 		pd.Reserved1 = 0
-		buf := media.NewDICOMBuffer()
-		buf.SetBigEndian(true)
-		buf.WriteByte(pd.ItemType)
-		buf.WriteByte(pd.Reserved1)
-		buf.WriteUint32(pd.Length)
-		buf.WriteUint32(pd.pdv.Length)
-		buf.WriteByte(pd.pdv.PresentationContextID)
-		buf.WriteByte(pd.MsgHeader)
-		if err := buf.Send(rw); err != nil {
+		if err := writePDVHeader(rw, pd.ItemType, pd.Reserved1, pd.Length, pd.pdv.Length, pd.pdv.PresentationContextID, pd.MsgHeader); err != nil {
 			return fmt.Errorf("pdata::Write: %w", err)
 		}
 		rw.Flush()
@@ -134,21 +143,14 @@ func (pd *PresentationDataTransfer) Write(rw *bufio.ReadWriter) error {
 		pd.Length = pd.pdv.Length + 4
 		pd.ItemType = pdutype.PDUDataTransfer
 		pd.Reserved1 = 0
-		buf := media.NewDICOMBuffer()
-
-		buf.SetBigEndian(true)
-		buf.WriteByte(pd.ItemType)
-		buf.WriteByte(pd.Reserved1)
-		buf.WriteUint32(pd.Length)
-		buf.WriteUint32(pd.pdv.Length)
-		buf.WriteByte(pd.pdv.PresentationContextID)
-		buf.WriteByte(pd.MsgHeader)
-
-		if err := buf.Send(rw); err != nil {
+		if err := writePDVHeader(rw, pd.ItemType, pd.Reserved1, pd.Length, pd.pdv.Length, pd.pdv.PresentationContextID, pd.MsgHeader); err != nil {
 			return fmt.Errorf("pdata::Write: %w", err)
 		}
 
-		buff, err := pd.Buffer.Read(int(pd.BlockSize))
+		// Zero-copy view into the send buffer: rw.Write copies these bytes into
+		// the bufio buffer immediately, and the send buffer is only read (never
+		// mutated) during Write, so the slice cannot be clobbered.
+		buff, err := pd.Buffer.ReadSlice(int(pd.BlockSize))
 		if err != nil {
 			return fmt.Errorf("pdata::Write: %w", err)
 		}

--- a/network/p_data_tf_benchmark_test.go
+++ b/network/p_data_tf_benchmark_test.go
@@ -1,0 +1,30 @@
+package network
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/media"
+)
+
+// BenchmarkPDataTFWriteManyBlocks fragments a 1 MiB payload at the default 4 KiB
+// block size (~256 PDV fragments). Each fragment previously allocated a fresh
+// 4 KiB DICOMBuffer just to emit a 12-byte header; the benchmark's allocs/op
+// makes that churn (and its removal) visible.
+func BenchmarkPDataTFWriteManyBlocks(b *testing.B) {
+	payload := make([]byte, 1<<20)
+	buf := media.NewDICOMBufferFromBytes(payload)
+	rw := bufio.NewReadWriter(bufio.NewReader(bytes.NewReader(nil)), bufio.NewWriter(io.Discard))
+	pd := &PresentationDataTransfer{Buffer: buf, PresentationContextID: 1}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pd.BlockSize = 4096 // Write shrinks BlockSize on the final fragment; reset each run.
+		if err := pd.Write(rw); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/services/scp_handlers.go
+++ b/services/scp_handlers.go
@@ -115,9 +115,6 @@ type subopResult struct {
 // writeSubopRSP is the function signature shared by CGetWriteRSP and CMoveWriteRSP.
 type writeSubopRSP func(pdu network.PDUService, req media.DICOMObject, status uint16, remaining, completed, failed, warnings uint16) error
 
-// runSubopLoop is the shared C-GET / C-MOVE event loop. It drives the
-// progress and result channels, handles C-CANCEL, polls for interleaved
-// commands, and writes DIMSE responses via writeRSP.
 // runSubopLoop drives the SCP-side event loop shared by C-GET and C-MOVE: it
 // streams Pending progress responses, enforces cancellation, forwards
 // interleaved commands, and writes the final response.

--- a/services/scp_handlers.go
+++ b/services/scp_handlers.go
@@ -118,13 +118,24 @@ type writeSubopRSP func(pdu network.PDUService, req media.DICOMObject, status ui
 // runSubopLoop is the shared C-GET / C-MOVE event loop. It drives the
 // progress and result channels, handles C-CANCEL, polls for interleaved
 // commands, and writes DIMSE responses via writeRSP.
+// runSubopLoop drives the SCP-side event loop shared by C-GET and C-MOVE: it
+// streams Pending progress responses, enforces cancellation, forwards
+// interleaved commands, and writes the final response.
+//
+// storeReqCh is the C-GET-only channel for C-STORE sub-operations that must run
+// synchronously on this event loop (C-GET ships matched instances back over the
+// same association). C-MOVE has no inline store and passes a nil channel — a
+// receive on a nil channel blocks forever, so that select case is simply never
+// selected.
 func (s *scp) runSubopLoop(
+	ctx context.Context,
 	rw *bufio.ReadWriter,
 	conn net.Conn,
 	pdu network.PDUService,
 	queue *[]media.DICOMObject,
 	requestCommandObj media.DICOMObject,
 	assocRQ network.AssociationRequest,
+	storeReqCh <-chan cgetStoreRequest,
 	progressCh <-chan subopProgress,
 	resultCh <-chan subopResult,
 	cancel context.CancelFunc,
@@ -142,6 +153,11 @@ func (s *scp) runSubopLoop(
 		}
 
 		select {
+		case req := <-storeReqCh:
+			// Perform the C-STORE sub-operation synchronously on the PDU event
+			// loop (C-GET only; nil for C-MOVE so this case never fires).
+			req.reply <- s.cgetStoreSubop(ctx, pdu, req.path)
+
 		case progress := <-progressCh:
 			if err := state.applyProgress(progress.Remaining, progress.Completed, progress.Failed, progress.Warnings); err != nil {
 				cancel()
@@ -400,90 +416,7 @@ func (s *scp) runCGetOperation(rw *bufio.ReadWriter, conn net.Conn, pdu network.
 		}
 	}()
 
-	messageID := requestCommandObj.GetUint16(tags.MessageID)
-	state := operationCounterState{}
-	canceled := false
-	var cancelDeadline time.Time
-
-	for {
-		if canceled && !cancelDeadline.IsZero() && time.Now().After(cancelDeadline) {
-			abortAssociation(rw, conn)
-			return errors.New("scp: C-GET sub-op handler did not exit within cancel grace window")
-		}
-
-		select {
-		case req := <-storeReqCh:
-			// Perform C-STORE sub-operation synchronously on the PDU event loop.
-			req.reply <- s.cgetStoreSubop(ctx, pdu, req.path)
-
-		case progress := <-progressCh:
-			if err := state.applyProgress(progress.Remaining, progress.Completed, progress.Failed, progress.Warnings); err != nil {
-				cancel()
-				return dimse.CGetWriteRSP(pdu, requestCommandObj, dicomstatus.FailureProcessingFailure, 0, state.completed, state.failed+1, state.warnings)
-			}
-			if err := dimse.CGetWriteRSP(pdu, requestCommandObj, dicomstatus.Pending, progress.Remaining, progress.Completed, progress.Failed, progress.Warnings); err != nil {
-				return err
-			}
-
-		case resp := <-resultCh:
-			// Drain any remaining pending progress messages.
-			drain := true
-			for drain {
-				select {
-				case progress := <-progressCh:
-					if err := state.applyProgress(progress.Remaining, progress.Completed, progress.Failed, progress.Warnings); err != nil {
-						return dimse.CGetWriteRSP(pdu, requestCommandObj, dicomstatus.FailureProcessingFailure, 0, state.completed, state.failed+1, state.warnings)
-					}
-					if err := dimse.CGetWriteRSP(pdu, requestCommandObj, dicomstatus.Pending, progress.Remaining, progress.Completed, progress.Failed, progress.Warnings); err != nil {
-						return err
-					}
-				default:
-					drain = false
-				}
-			}
-
-			if resp.Err != nil {
-				if canceled {
-					return dimse.CGetWriteRSP(pdu, requestCommandObj, dicomstatus.Cancel, 0, state.completed, state.failed, state.warnings)
-				}
-				return dimse.CGetWriteRSP(pdu, requestCommandObj, dicomstatus.FailureProcessingFailure, 0, state.completed, state.failed+1, state.warnings)
-			}
-
-			final := resp
-			if final.Completed == 0 && final.Failed == 0 && final.Warnings == 0 {
-				final.Completed = state.completed
-				final.Failed = state.failed
-				final.Warnings = state.warnings
-			}
-
-			status, remaining, completed, failed, warnings, err := state.finalize(final.Status, final.Remaining, final.Completed, final.Failed, final.Warnings, canceled)
-			if err != nil {
-				return dimse.CGetWriteRSP(pdu, requestCommandObj, dicomstatus.FailureProcessingFailure, 0, state.completed, state.failed+1, state.warnings)
-			}
-			return dimse.CGetWriteRSP(pdu, requestCommandObj, status, remaining, completed, failed, warnings)
-
-		default:
-			dco, err := s.pollCommand(conn, pdu)
-			if err != nil {
-				return err
-			}
-			if dco == nil {
-				continue
-			}
-			if dco.GetUint16(tags.CommandField) == dicomcommand.CCancelRequest {
-				cancelMessageID := s.handleCancelCommand(pdu.Logger(), assocRQ, dco)
-				if cancelMessageID == messageID {
-					canceled = true
-					if cancelDeadline.IsZero() {
-						cancelDeadline = time.Now().Add(s.cancelGrace)
-					}
-					cancel()
-				}
-				continue
-			}
-			*queue = append(*queue, dco)
-		}
-	}
+	return s.runSubopLoop(ctx, rw, conn, pdu, queue, requestCommandObj, assocRQ, storeReqCh, progressCh, resultCh, cancel, dimse.CGetWriteRSP)
 }
 
 func (s *scp) runCMoveOperation(rw *bufio.ReadWriter, conn net.Conn, pdu network.PDUService, queue *[]media.DICOMObject, requestCommandObj media.DICOMObject, assocRQ network.AssociationRequest, moveDestAE string, moveLevel string, query media.DICOMObject, handler CMoveHandler) error {
@@ -511,7 +444,9 @@ func (s *scp) runCMoveOperation(rw *bufio.ReadWriter, conn net.Conn, pdu network
 		}
 	}()
 
-	return s.runSubopLoop(rw, conn, pdu, queue, requestCommandObj, assocRQ, progressCh, resultCh, cancel, dimse.CMoveWriteRSP)
+	// C-MOVE has no inline C-STORE sub-operation (instances go to a separate
+	// destination AE), so it passes a nil store channel.
+	return s.runSubopLoop(ctx, rw, conn, pdu, queue, requestCommandObj, assocRQ, nil, progressCh, resultCh, cancel, dimse.CMoveWriteRSP)
 }
 
 func (s *scp) OnAssociationRequest(f func(request network.AssociationRequest) bool) {


### PR DESCRIPTION
Two small, independent cleanups closing out the roadmap. Reviewable per-commit.

## 1. Fold the C-GET event loop into `runSubopLoop` (the C-Get/C-Move question)
`runCGetOperation` duplicated nearly the **entire** body of `runSubopLoop` (already shared with C-MOVE) — the cancel-deadline check, Pending-progress streaming, result drain/finalize, and interleaved-command handling were copy-pasted, differing only by one extra `select` case for synchronous C-STORE sub-operations.

- Added an optional `storeReqCh` (and `ctx`) to `runSubopLoop` and moved the store case into its `select`.
- C-MOVE passes a **nil** channel; a receive on a nil channel blocks forever, so that case is simply never selected for C-MOVE.
- `runCGetOperation` now just wires its channels and delegates, mirroring `runCMoveOperation`.

Net **−65 lines**, behavior-preserving. Covered by the existing C-GET cancel/progress/store-subop tests (pass under `-race`).

## 2. Stop per-fragment allocations in `PresentationDataTransfer.Write` (§4)
The P-DATA-TF send loop allocated a fresh **4 KiB `DICOMBuffer` per PDV** just to emit a 12-byte header, and copied each payload chunk out of the send buffer.

- Build the 12-byte header on the stack via `encoding/binary` (`writePDVHeader`).
- Read each chunk with the zero-copy `ReadSlice` instead of `Read` (`rw.Write` copies into the bufio buffer immediately; the send buffer is only read during `Write`, so aliasing is safe).

**Benchmark** (1 MiB payload, 4 KiB blocks → ~256 fragments):
```
before: 240598 ns/op  2097157 B/op  512 allocs/op
after:   21382 ns/op     4096 B/op  256 allocs/op
```
~11× faster, ~500× less memory allocated. Wire output unchanged.

## Verification
- `go build ./...` / `go vet ./...` / `staticcheck ./...` — clean
- `go test -race ./...` — pass
- New `BenchmarkPDataTFWriteManyBlocks` added

🤖 Generated with [Claude Code](https://claude.com/claude-code)