### PR TITLE
Harden association PDU decoders against malformed input

### DIFF
--- a/network/a_association_ac.go
+++ b/network/a_association_ac.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/innovative-io/io-dicom/dictionary/sopclass"
-	"github.com/innovative-io/io-dicom/dictionary/transfersyntax"
 	implementation "github.com/innovative-io/io-dicom/internal/implclass"
 	"github.com/innovative-io/io-dicom/media"
 	"github.com/innovative-io/io-dicom/network/internal/pdutype"
@@ -197,15 +196,21 @@ func (aaac *associationAccept) ReadDynamic(buf *media.DICOMBuffer) (err error) {
 
 		switch TempByte {
 		case pdutype.ApplicationContextItem:
-			aaac.AppContext.ReadDynamic(buf)
+			if err := aaac.AppContext.ReadDynamic(buf); err != nil {
+				return err
+			}
 			Count = Count - int(aaac.AppContext.GetSize())
 		case pdutype.PresentationContextAcceptItem:
 			PresContextAccept := NewPresentationContextAccept()
-			PresContextAccept.ReadDynamic(buf)
+			if err := PresContextAccept.ReadDynamic(buf); err != nil {
+				return err
+			}
 			Count = Count - int(PresContextAccept.Size())
 			aaac.PresContextAccepts = append(aaac.PresContextAccepts, PresContextAccept)
 		case pdutype.UserInformationItem: // User Information
-			aaac.UserInfo.ReadDynamic(buf)
+			if err := aaac.UserInfo.ReadDynamic(buf); err != nil {
+				return err
+			}
 			Count = Count - int(aaac.UserInfo.Size())
 		default:
 			Count = -1
@@ -221,13 +226,13 @@ func (aaac *associationAccept) ReadDynamic(buf *media.DICOMBuffer) (err error) {
 		"their_impl_class", aaac.UserInfo.GetImplementationClass().GetUID(),
 		"their_impl_version", aaac.UserInfo.GetImplementationVersion().GetUID(),
 		"app_context", aaac.AppContext.GetUID(),
-		"app_context_description", sopclass.GetSOPClassFromUID(aaac.AppContext.GetUID()).Description,
+		"app_context_description", sopClassDescription(aaac.AppContext.GetUID()),
 		"our_max_pdu_length", maxPduLength, "their_max_pdu_length", aaac.GetMaxSubLength())
 	for presIndex, presContextAccept := range aaac.PresContextAccepts {
 		aaLog.Debug("accepted presentation context",
 			"index", presIndex+1, "pcid", presContextAccept.GetPresentationContextID(),
 			"transfer_syntax", presContextAccept.GetTrnSyntax().GetUID(),
-			"transfer_syntax_description", transfersyntax.GetTransferSyntaxFromUID(presContextAccept.GetTrnSyntax().GetUID()).Description)
+			"transfer_syntax_description", transferSyntaxDescription(presContextAccept.GetTrnSyntax().GetUID()))
 	}
 	if Count == 0 {
 		return nil

--- a/network/a_association_ac.go
+++ b/network/a_association_ac.go
@@ -189,6 +189,7 @@ func (aaac *associationAccept) ReadDynamic(buf *media.DICOMBuffer) (err error) {
 	Count := int(aaac.Length - 4 - 16 - 16 - 32)
 
 	for Count > 0 {
+		startPos := buf.GetPosition()
 		TempByte, err := buf.GetByte()
 		if err != nil {
 			return err
@@ -199,23 +200,22 @@ func (aaac *associationAccept) ReadDynamic(buf *media.DICOMBuffer) (err error) {
 			if err := aaac.AppContext.ReadDynamic(buf); err != nil {
 				return err
 			}
-			Count = Count - int(aaac.AppContext.GetSize())
 		case pdutype.PresentationContextAcceptItem:
 			PresContextAccept := NewPresentationContextAccept()
 			if err := PresContextAccept.ReadDynamic(buf); err != nil {
 				return err
 			}
-			Count = Count - int(PresContextAccept.Size())
 			aaac.PresContextAccepts = append(aaac.PresContextAccepts, PresContextAccept)
 		case pdutype.UserInformationItem: // User Information
 			if err := aaac.UserInfo.ReadDynamic(buf); err != nil {
 				return err
 			}
-			Count = Count - int(aaac.UserInfo.Size())
 		default:
-			Count = -1
 			return errors.New("aaac::ReadDynamic, unknown Item " + strconv.Itoa(int(TempByte)))
 		}
+		// Decrement by bytes actually consumed; the per-item uint16 Size()/GetSize()
+		// could wrap on a malformed large length and corrupt the accounting.
+		Count -= buf.GetPosition() - startPos
 	}
 
 	aaLog := loggerOrDefault(aaac.logger)

--- a/network/a_association_rq.go
+++ b/network/a_association_rq.go
@@ -235,6 +235,7 @@ func (aarq *associationRequest) Read(buf *media.DICOMBuffer) (err error) {
 
 	Count := int(buf.GetSize() - 4 - 16 - 16 - 32)
 	for Count > 0 {
+		startPos := buf.GetPosition()
 		TempByte, err := buf.GetByte()
 		if err != nil {
 			return err
@@ -246,20 +247,21 @@ func (aarq *associationRequest) Read(buf *media.DICOMBuffer) (err error) {
 			if err := aarq.AppContext.ReadDynamic(buf); err != nil {
 				return err
 			}
-			Count = Count - int(aarq.AppContext.GetSize())
 		case pdutype.PresentationContextItem:
 			PresContext := NewPresentationContext()
 			if err := PresContext.ReadDynamic(buf); err != nil {
 				return err
 			}
-			Count = Count - int(PresContext.Size())
 			aarq.PresContexts = append(aarq.PresContexts, PresContext)
 		case pdutype.UserInformationItem: // User Information
 			return aarq.UserInfo.ReadDynamic(buf)
 		default:
 			loggerOrDefault(aarq.logger).Error("unknown A-ASSOCIATE-RQ item", "item_type", TempByte)
-			Count = -1
+			return errors.New("aarq::ReadDynamic, unknown item type")
 		}
+		// Decrement by bytes actually consumed; the per-item uint16 Size()/GetSize()
+		// could wrap on a malformed large length and corrupt the accounting.
+		Count -= buf.GetPosition() - startPos
 	}
 
 	if Count == 0 {

--- a/network/a_association_rq.go
+++ b/network/a_association_rq.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 
 	"github.com/innovative-io/io-dicom/dictionary/sopclass"
-	"github.com/innovative-io/io-dicom/dictionary/transfersyntax"
 	"github.com/innovative-io/io-dicom/media"
 	"github.com/innovative-io/io-dicom/network/internal/pdutype"
 )
@@ -202,7 +201,7 @@ func (aarq *associationRequest) Write(rw *bufio.ReadWriter) error {
 		return err
 	}
 
-	aaLog.Debug("application context", "uid", aarq.AppContext.GetUID(), "description", sopclass.GetSOPClassFromUID(aarq.AppContext.GetUID()).Description)
+	aaLog.Debug("application context", "uid", aarq.AppContext.GetUID(), "description", sopClassDescription(aarq.AppContext.GetUID()))
 	if err := aarq.AppContext.Write(rw); err != nil {
 		return err
 	}
@@ -210,10 +209,10 @@ func (aarq *associationRequest) Write(rw *bufio.ReadWriter) error {
 		aaLog.Debug("proposed presentation context",
 			"index", presIndex+1, "pcid", presContext.GetPresentationContextID(),
 			"abstract_syntax", presContext.GetAbstractSyntax().GetUID(),
-			"abstract_syntax_description", sopclass.GetSOPClassFromUID(presContext.GetAbstractSyntax().GetUID()).Description)
+			"abstract_syntax_description", sopClassDescription(presContext.GetAbstractSyntax().GetUID()))
 		for _, transSyntax := range presContext.GetTransferSyntaxes() {
 			aaLog.Debug("proposed transfer syntax",
-				"uid", transSyntax.GetUID(), "description", transfersyntax.GetTransferSyntaxFromUID(transSyntax.GetUID()).Description)
+				"uid", transSyntax.GetUID(), "description", transferSyntaxDescription(transSyntax.GetUID()))
 		}
 		if err := presContext.Write(rw); err != nil {
 			return err
@@ -244,16 +243,19 @@ func (aarq *associationRequest) Read(buf *media.DICOMBuffer) (err error) {
 		switch TempByte {
 		case pdutype.ApplicationContextItem:
 			aarq.AppContext.SetType(TempByte)
-			aarq.AppContext.ReadDynamic(buf)
+			if err := aarq.AppContext.ReadDynamic(buf); err != nil {
+				return err
+			}
 			Count = Count - int(aarq.AppContext.GetSize())
 		case pdutype.PresentationContextItem:
 			PresContext := NewPresentationContext()
-			PresContext.ReadDynamic(buf)
+			if err := PresContext.ReadDynamic(buf); err != nil {
+				return err
+			}
 			Count = Count - int(PresContext.Size())
 			aarq.PresContexts = append(aarq.PresContexts, PresContext)
 		case pdutype.UserInformationItem: // User Information
-			aarq.UserInfo.ReadDynamic(buf)
-			return nil
+			return aarq.UserInfo.ReadDynamic(buf)
 		default:
 			loggerOrDefault(aarq.logger).Error("unknown A-ASSOCIATE-RQ item", "item_type", TempByte)
 			Count = -1

--- a/network/decoder_regression_test.go
+++ b/network/decoder_regression_test.go
@@ -1,0 +1,62 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/innovative-io/io-dicom/media"
+)
+
+// TestDescriptionHelpers_UnknownUIDNoNilPanic guards the nil dereference that
+// FuzzAssociationACReadDynamic found: sopclass.GetSOPClassFromUID and
+// transfersyntax.GetTransferSyntaxFromUID return nil for unknown UIDs, and the
+// A-ASSOCIATE log lines dereferenced .Description on the result.
+func TestDescriptionHelpers_UnknownUIDNoNilPanic(t *testing.T) {
+	if got := sopClassDescription("9.9.9.not.a.real.uid"); got != "" {
+		t.Errorf("sopClassDescription(unknown) = %q, want empty string", got)
+	}
+	if got := transferSyntaxDescription("9.9.9.not.a.real.uid"); got != "" {
+		t.Errorf("transferSyntaxDescription(unknown) = %q, want empty string", got)
+	}
+}
+
+// TestPresentationContextReadDynamic_TruncatedRejected guards the uint16
+// underflow that spun presentationContext.ReadDynamic forever on a malformed
+// context (found by FuzzAssociationRQRead). The transfer-syntax loop counter
+// could wrap past zero back to ~65535 on a truncated item.
+//
+// The input declares Length=32 but supplies only an abstract-syntax item of
+// odd UID length (so the post-abstract "remaining" is 19, not a multiple of 4)
+// and no transfer syntax bytes. ReadDynamic must return an error promptly; if
+// the underflow regressed, this test would hang and the package -timeout would
+// fail the run.
+func TestPresentationContextReadDynamic_TruncatedRejected(t *testing.T) {
+	data := []byte{
+		0x00,       // Reserved1
+		0x00, 0x20, // Length = 32
+		0x01,             // PresentationContextID
+		0x00, 0x00, 0x00, // Reserved2/3/4
+		// Abstract syntax item: type, reserved, length=5, 5 UID bytes.
+		0x30, 0x00, 0x00, 0x05, '1', '.', '2', '.', '3',
+		// (no transfer syntax bytes — buffer is now exhausted)
+	}
+	pc := NewPresentationContext().(*presentationContext)
+	buf := media.NewDICOMBufferFromBytes(data)
+	buf.SetBigEndian(true)
+	if err := pc.ReadDynamic(buf); err == nil {
+		t.Fatal("expected an error decoding a truncated presentation context, got nil")
+	}
+}
+
+// TestAssociationRQRead_TruncatedRejected feeds a structurally valid header but
+// a truncated item body to the full A-ASSOCIATE-RQ decoder; it must return an
+// error rather than panic or hang.
+func TestAssociationRQRead_TruncatedRejected(t *testing.T) {
+	data := make([]byte, 4+16+16+32) // protocol version + reserved + AE titles + reserved
+	data = append(data, 0x20)        // a presentation-context item type byte, then nothing
+	aarq := newAssociationRequest()
+	buf := media.NewDICOMBufferFromBytes(data)
+	buf.SetBigEndian(true)
+	if err := aarq.Read(buf); err == nil {
+		t.Fatal("expected an error decoding a truncated A-ASSOCIATE-RQ, got nil")
+	}
+}

--- a/network/descriptions.go
+++ b/network/descriptions.go
@@ -1,0 +1,26 @@
+package network
+
+import (
+	"github.com/innovative-io/io-dicom/dictionary/sopclass"
+	"github.com/innovative-io/io-dicom/dictionary/transfersyntax"
+)
+
+// sopClassDescription returns the human-readable description for a SOP class
+// UID, or "" when the UID is unknown. GetSOPClassFromUID returns nil for
+// unrecognized UIDs, so this guard prevents a nil dereference when logging the
+// description of an attacker-supplied or malformed application/abstract syntax.
+func sopClassDescription(uid string) string {
+	if sc := sopclass.GetSOPClassFromUID(uid); sc != nil {
+		return sc.Description
+	}
+	return ""
+}
+
+// transferSyntaxDescription returns the description for a transfer syntax UID,
+// or "" when the UID is unknown (GetTransferSyntaxFromUID returns nil).
+func transferSyntaxDescription(uid string) string {
+	if ts := transfersyntax.GetTransferSyntaxFromUID(uid); ts != nil {
+		return ts.Description
+	}
+	return ""
+}

--- a/network/fuzz_assoc_test.go
+++ b/network/fuzz_assoc_test.go
@@ -1,0 +1,41 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/innovative-io/io-dicom/media"
+)
+
+// FuzzAssociationRQRead drives the A-ASSOCIATE-RQ decoder (the SCP-side parse of
+// an incoming association request) with arbitrary bytes. Decoding attacker-
+// controlled PDU items must never panic or hang — an error return is fine.
+// Run with: go test -run=^$ -fuzz=FuzzAssociationRQRead ./network
+func FuzzAssociationRQRead(f *testing.F) {
+	f.Add([]byte{})
+	// Protocol version + reserved + 16+16 AE + 32 reserved, then a truncated item.
+	f.Add([]byte{0x00, 0x01, 0x00, 0x00})
+	f.Add(make([]byte, 4+16+16+32+1))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		aarq := newAssociationRequest()
+		buf := media.NewDICOMBufferFromBytes(data)
+		buf.SetBigEndian(true)
+		_ = aarq.Read(buf)
+	})
+}
+
+// FuzzAssociationACReadDynamic drives the A-ASSOCIATE-AC decoder (the SCU-side
+// parse of the peer's acceptance) with arbitrary bytes.
+// Run with: go test -run=^$ -fuzz=FuzzAssociationACReadDynamic ./network
+func FuzzAssociationACReadDynamic(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{0x00, 0x00, 0x00, 0x00, 0x10})
+	f.Add(make([]byte, 1+4+2+2+16+16+32+1))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		aaac := newAssociationAccept()
+		buf := media.NewDICOMBufferFromBytes(data)
+		buf.SetBigEndian(true)
+		_ = aaac.ReadDynamic(buf)
+	})
+}

--- a/network/pdu_service.go
+++ b/network/pdu_service.go
@@ -389,7 +389,9 @@ func (pdu *pduService) finishConnect(conn net.Conn) error {
 	switch itemType {
 	case pdutype.AssociationAccept:
 		pdu.buf.SetPosition(1)
-		pdu.AssocAC.ReadDynamic(pdu.buf)
+		if err := pdu.AssocAC.ReadDynamic(pdu.buf); err != nil {
+			return err
+		}
 		pdu.emitRawPDU(RawPDUDirectionInbound, itemType, rawData)
 		if !pdu.interogateAAssociateAC() {
 			return errors.New("pduservice::Connect - No accepted presentation contexts found")
@@ -428,12 +430,16 @@ func (pdu *pduService) finishConnect(conn net.Conn) error {
 		return nil
 	case pdutype.AssociationReject:
 		pdu.buf.SetPosition(1)
-		pdu.AssocRJ.ReadDynamic(pdu.buf)
+		if err := pdu.AssocRJ.ReadDynamic(pdu.buf); err != nil {
+			return err
+		}
 		pdu.emitRawPDU(RawPDUDirectionInbound, itemType, rawData)
 		return fmt.Errorf("pduservice::Connect - Association rejected - %s", pdu.AssocRJ.GetReason())
 	case pdutype.AssociationAbortRequest:
 		pdu.buf.SetPosition(1)
-		pdu.AbortRQ.ReadDynamic(pdu.buf)
+		if err := pdu.AbortRQ.ReadDynamic(pdu.buf); err != nil {
+			return err
+		}
 		pdu.emitRawPDU(RawPDUDirectionInbound, itemType, rawData)
 		return fmt.Errorf("pduservice::Connect - Association aborted - %s", pdu.AbortRQ.GetReason())
 	default:
@@ -494,7 +500,9 @@ func (pdu *pduService) NextPDU() (command media.DICOMObject, err error) {
 	pdu.Pdata.MsgStatus = 0
 	if pdu.Pdata.Length != 0 {
 		DCO := media.NewEmptyDCMObj()
-		pdu.Pdata.ReadDynamic(pdu.buf)
+		if err := pdu.Pdata.ReadDynamic(pdu.buf); err != nil {
+			return nil, err
+		}
 		if pdu.Pdata.MsgStatus > 0 {
 			if !pdu.parseRawVRIntoDCM(DCO) {
 				pdu.AbortRQ.Write(pdu.readWriter)
@@ -546,7 +554,9 @@ func (pdu *pduService) NextPDU() (command media.DICOMObject, err error) {
 			pdu.logger.Debug("A-RELEASE-RQ received")
 			pdu.emitRawPDU(RawPDUDirectionInbound, itemType, rawData)
 			pdu.buf.SetPosition(1)
-			pdu.ReleaseRQ.ReadDynamic(pdu.buf)
+			if err := pdu.ReleaseRQ.ReadDynamic(pdu.buf); err != nil {
+				return nil, err
+			}
 			if err := pdu.writeEncodedPDU(byte(pdutype.AssociationReleaseResponse), func(rw *bufio.ReadWriter) error {
 				return pdu.ReleaseRP.Write(rw)
 			}); err != nil {

--- a/network/presentation_context.go
+++ b/network/presentation_context.go
@@ -134,10 +134,12 @@ func (pc *presentationContext) ReadDynamic(buf *media.DICOMBuffer) (err error) {
 		return err
 	}
 
-	// Use a signed counter: pc.Length and GetSize are uint16, so the original
-	// "remaining -= size" could underflow below zero and wrap to ~65535, spinning
-	// this loop forever on a malformed/truncated context (a CPU-bound DoS found by
-	// FuzzAssociationRQRead). A signed remaining goes negative and exits cleanly.
+	// Decrement by the bytes actually consumed (a signed position delta) rather
+	// than by uidItem.GetSize(): GetSize computes length+4 in uint16 and wraps for
+	// large lengths, and the original uint16 "remaining" could underflow past zero
+	// to ~65535 — either of which spun this loop forever on a malformed/truncated
+	// context (a CPU-bound DoS found by FuzzAssociationRQRead). A signed remaining
+	// driven by real progress goes to/below zero and exits cleanly.
 	remaining := int(pc.Length) - 4 - int(pc.AbsSyntax.GetSize())
 	for remaining > 0 {
 		startPos := buf.GetPosition()
@@ -145,12 +147,13 @@ func (pc *presentationContext) ReadDynamic(buf *media.DICOMBuffer) (err error) {
 		if err := transferSyntax.Read(buf); err != nil {
 			return err
 		}
+		consumed := buf.GetPosition() - startPos
 		// Defense in depth: if an item consumed no bytes the loop cannot make
 		// progress; bail rather than risk spinning.
-		if buf.GetPosition() <= startPos {
+		if consumed <= 0 {
 			return errors.New("pc::ReadDynamic, transfer syntax item made no progress")
 		}
-		remaining -= int(transferSyntax.GetSize())
+		remaining -= consumed
 		pc.TrnSyntaxs = append(pc.TrnSyntaxs, &transferSyntax)
 	}
 

--- a/network/presentation_context.go
+++ b/network/presentation_context.go
@@ -134,17 +134,27 @@ func (pc *presentationContext) ReadDynamic(buf *media.DICOMBuffer) (err error) {
 		return err
 	}
 
-	remainingBytes := pc.Length - 4 - pc.AbsSyntax.GetSize()
-	for remainingBytes > 0 {
+	// Use a signed counter: pc.Length and GetSize are uint16, so the original
+	// "remaining -= size" could underflow below zero and wrap to ~65535, spinning
+	// this loop forever on a malformed/truncated context (a CPU-bound DoS found by
+	// FuzzAssociationRQRead). A signed remaining goes negative and exits cleanly.
+	remaining := int(pc.Length) - 4 - int(pc.AbsSyntax.GetSize())
+	for remaining > 0 {
+		startPos := buf.GetPosition()
 		var transferSyntax uidItem
-		transferSyntax.Read(buf)
-		remainingBytes = remainingBytes - transferSyntax.GetSize()
-		if transferSyntax.GetSize() > 0 {
-			pc.TrnSyntaxs = append(pc.TrnSyntaxs, &transferSyntax)
+		if err := transferSyntax.Read(buf); err != nil {
+			return err
 		}
+		// Defense in depth: if an item consumed no bytes the loop cannot make
+		// progress; bail rather than risk spinning.
+		if buf.GetPosition() <= startPos {
+			return errors.New("pc::ReadDynamic, transfer syntax item made no progress")
+		}
+		remaining -= int(transferSyntax.GetSize())
+		pc.TrnSyntaxs = append(pc.TrnSyntaxs, &transferSyntax)
 	}
 
-	if remainingBytes == 0 {
+	if remaining == 0 {
 		return nil
 	}
 

--- a/network/user_information.go
+++ b/network/user_information.go
@@ -129,20 +129,30 @@ func (ui *userInformation) ReadDynamic(buf *media.DICOMBuffer) (err error) {
 
 		switch TempByte {
 		case pdutype.MaximumSubLengthItem:
-			ui.MaxSubLength.ReadDynamic(buf)
+			if err := ui.MaxSubLength.ReadDynamic(buf); err != nil {
+				return err
+			}
 			Count = Count - int(ui.MaxSubLength.Size())
 		case pdutype.ImplementationClassUIDItem:
-			ui.ImpClass.ReadDynamic(buf)
+			if err := ui.ImpClass.ReadDynamic(buf); err != nil {
+				return err
+			}
 			Count = Count - int(ui.ImpClass.GetSize())
 		case pdutype.AsyncOperationsWindowItem:
-			ui.AsyncOpWindow.ReadDynamic(buf)
+			if err := ui.AsyncOpWindow.ReadDynamic(buf); err != nil {
+				return err
+			}
 			Count = Count - int(ui.AsyncOpWindow.Size())
 		case pdutype.SCPSCURoleSelectionItem:
-			ui.SCPSCURole.ReadDynamic(buf)
+			if err := ui.SCPSCURole.ReadDynamic(buf); err != nil {
+				return err
+			}
 			Count = Count - int(ui.SCPSCURole.Size())
 			ui.UserInfoBaggage += uint32(ui.SCPSCURole.Size())
 		case pdutype.ImplementationVersionNameItem:
-			ui.ImpVersion.ReadDynamic(buf)
+			if err := ui.ImpVersion.ReadDynamic(buf); err != nil {
+				return err
+			}
 			Count = Count - int(ui.ImpVersion.GetSize())
 		default:
 			ui.UserInfoBaggage = uint32(Count)

--- a/network/user_information.go
+++ b/network/user_information.go
@@ -122,6 +122,7 @@ func (ui *userInformation) ReadDynamic(buf *media.DICOMBuffer) (err error) {
 
 	Count := int(ui.Length)
 	for Count > 0 {
+		startPos := buf.GetPosition()
 		TempByte, err := buf.GetByte()
 		if err != nil {
 			return err
@@ -132,33 +133,31 @@ func (ui *userInformation) ReadDynamic(buf *media.DICOMBuffer) (err error) {
 			if err := ui.MaxSubLength.ReadDynamic(buf); err != nil {
 				return err
 			}
-			Count = Count - int(ui.MaxSubLength.Size())
 		case pdutype.ImplementationClassUIDItem:
 			if err := ui.ImpClass.ReadDynamic(buf); err != nil {
 				return err
 			}
-			Count = Count - int(ui.ImpClass.GetSize())
 		case pdutype.AsyncOperationsWindowItem:
 			if err := ui.AsyncOpWindow.ReadDynamic(buf); err != nil {
 				return err
 			}
-			Count = Count - int(ui.AsyncOpWindow.Size())
 		case pdutype.SCPSCURoleSelectionItem:
 			if err := ui.SCPSCURole.ReadDynamic(buf); err != nil {
 				return err
 			}
-			Count = Count - int(ui.SCPSCURole.Size())
 			ui.UserInfoBaggage += uint32(ui.SCPSCURole.Size())
 		case pdutype.ImplementationVersionNameItem:
 			if err := ui.ImpVersion.ReadDynamic(buf); err != nil {
 				return err
 			}
-			Count = Count - int(ui.ImpVersion.GetSize())
 		default:
 			ui.UserInfoBaggage = uint32(Count)
-			Count = -1
 			return errors.New("user::ReadDynamic, unknown TempByte: " + strconv.Itoa(int(TempByte)))
 		}
+		// Decrement by bytes actually consumed (GetByte advances by at least one
+		// each iteration, so this terminates). The per-item uint16 Size()/GetSize()
+		// could wrap on a malformed large length and corrupt the accounting.
+		Count -= buf.GetPosition() - startPos
 	}
 
 	if Count == 0 {


### PR DESCRIPTION
Fuzzing the A-ASSOCIATE-RQ/AC decoders (the deepest layer of the network parse path, where the §1 hardening didn't reach) surfaced **two real DoS/crash bugs** and a class of silently-swallowed parse errors.

## Bugs fixed

### 🔴 Infinite loop — CPU-bound DoS (found by `FuzzAssociationRQRead`)
`presentationContext.ReadDynamic` tracked the transfer-syntax remaining length in a **uint16** and decremented it by the item size. On a truncated context the counter could step past zero (e.g. `3 - 4`) and **wrap back to ~65535**, spinning the parse loop forever on an exhausted buffer — a single malformed A-ASSOCIATE-RQ hangs the SCP's connection goroutine. Fixed with a signed counter, error propagation on the item read, and a no-progress guard.

### 🔴 Nil-pointer panic (found by `FuzzAssociationACReadDynamic`)
The A-ASSOCIATE Debug log lines dereferenced `GetSOPClassFromUID(uid).Description` / `GetTransferSyntaxFromUID(uid).Description`, both of which return **nil for unknown UIDs**. A garbage application/abstract/transfer-syntax UID crashed the decoder. Added nil-safe `sopClassDescription` / `transferSyntaxDescription` helpers and routed all 5 sites through them.

### 🟠 Swallowed parse errors (16 sites)
`ReadDynamic` returns an error at every level, but 16 call sites across `a_association_rq.go`, `a_association_ac.go`, `user_information.go`, and `pdu_service.go` discarded it and kept parsing from corrupt state. All now propagate — malformed sub-items fail cleanly instead of producing a half-decoded association.

## Tests
- New fuzz targets `FuzzAssociationRQRead` and `FuzzAssociationACReadDynamic` (the existing fuzzers covered `readIncomingPDU` and the PDV path, not these decoder loops).
- Readable regression unit tests for each bug class (`decoder_regression_test.go`) — the raw fuzz crasher corpus lives under gitignored `testdata/`, so the regressions are captured as deterministic unit tests instead.

## Verification
- `go build ./...` / `go vet ./...` / `staticcheck ./...` — clean
- `go test -race ./...` — pass
- All five fuzzers run 30s+ with no crashes or hangs

## Follow-up (not in this PR)
While wiring this up I evaluated adding **`errcheck` to CI** (the linter that would have caught the swallowed errors). It reports **210 findings module-wide** — but the large majority are `WriteByte` to *in-memory* buffers (cannot fail) and CLI codegen `fmt.Fprintln`. Turning it into a clean CI gate needs a dedicated exclusion policy plus fixing the genuine read-path findings, so it deserves its own focused PR rather than bloating this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)