### PR TITLE
feat(jpegls): pure-Go JPEG-LS near-lossless (.81) decode and encode

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"782d5a43-ee61-4d83-9e61-a05a2e505a21","pid":86048,"procStart":"Thu Jun  4 05:58:29 2026","acquiredAt":1780556477825}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"782d5a43-ee61-4d83-9e61-a05a2e505a21","pid":86048,"procStart":"Thu Jun  4 05:58:29 2026","acquiredAt":1780556477825}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ datastore
 .local
 testdata/
 bench/transcode/dcmtk_transcode_bench
+
+# Local Claude Code tooling state (settings, scheduled-task locks, etc.)
+.claude/

--- a/codecs/jpegls/gojpegls.go
+++ b/codecs/jpegls/gojpegls.go
@@ -255,7 +255,10 @@ func (d *jlsDecoder) decodeRegular(q, sign, px int) int {
 	}
 	errval := unmapErrval(d.decodeValue(k, d.limit))
 	// k==0 bias flip (GetErrorCorrection: ErrVal ^= -1 when 2B+N-1 < 0).
-	if k == 0 && 2*d.b[q]+d.n[q]-1 < 0 {
+	// CharLS calls get_error_correction(near_lossless), which returns 0 whenever
+	// its argument is nonzero — so the flip applies in pure-lossless mode only
+	// (NEAR==0). In near-lossless mode the correction is never applied.
+	if k == 0 && d.f.near == 0 && 2*d.b[q]+d.n[q]-1 < 0 {
 		errval = -errval - 1
 	}
 	rx := d.computeRecon(px, sign*errval)

--- a/codecs/jpegls/gojpegls_encode.go
+++ b/codecs/jpegls/gojpegls_encode.go
@@ -308,7 +308,11 @@ func encodeJLS(raw []byte, width, height, samples, precision, near int) ([]byte,
 	if width <= 0 || height <= 0 || samples != 1 || precision < 2 || precision > 16 {
 		return nil, errJLSUnsupported
 	}
-	if near < 0 {
+	// NEAR is written as a single byte in the SOS scan header and must not exceed
+	// MAXVAL (T.87 C.2.4.1.1). Reject out-of-range values rather than truncating
+	// them into a non-conformant stream.
+	maxval := (1 << precision) - 1
+	if near < 0 || near > 255 || near > maxval {
 		return nil, errJLSUnsupported
 	}
 	bps := 1

--- a/codecs/jpegls/gojpegls_encode.go
+++ b/codecs/jpegls/gojpegls_encode.go
@@ -66,23 +66,25 @@ func (d *jlsDecoder) encodeValue(w *jlsBitWriter, merr, k, limit int) {
 }
 
 // encodeRegular encodes one regular-mode sample (inverse of decodeRegular).
-func (d *jlsDecoder) encodeRegular(w *jlsBitWriter, q, sign, px, sample int) {
+func (d *jlsDecoder) encodeRegular(w *jlsBitWriter, q, sign, px, sample int) int {
 	k := 0
 	for (d.n[q] << k) < d.a[q] {
 		k++
 	}
-	// errval such that the decoder reconstructs `sample` from px.
-	errval := sign * (sample - px)
-	// reduce into [-RANGE/2, RANGE/2) consistently with decode (NEAR=0 here).
+	// errval such that the decoder reconstructs an in-tolerance sample from px.
+	// For near-lossless the prediction error is quantized (CharLS quantize), then
+	// reduced modulo RANGE consistently with the decoder.
+	errval := d.quantizeError(sign * (sample - px))
 	half := d.range_ / 2
 	if errval < -half {
 		errval += d.range_
 	} else if errval >= d.range_-half {
 		errval -= d.range_
 	}
-	// inverse of the k==0 bias flip
+	// inverse of the k==0 bias flip; applies in pure-lossless mode only (NEAR==0),
+	// matching the decoder / CharLS get_error_correction(near_lossless).
 	mapped := errval
-	if k == 0 && 2*d.b[q]+d.n[q]-1 < 0 {
+	if k == 0 && d.f.near == 0 && 2*d.b[q]+d.n[q]-1 < 0 {
 		mapped = -errval - 1
 	}
 	var merr int
@@ -93,11 +95,27 @@ func (d *jlsDecoder) encodeRegular(w *jlsBitWriter, q, sign, px, sample int) {
 	}
 	d.encodeValue(w, merr, k, d.limit)
 	d.updateRegular(q, errval)
+	// Return the value the decoder will reconstruct, so the encoder feeds
+	// reconstructed (not original) neighbors — required for near-lossless.
+	return d.computeRecon(px, sign*errval)
+}
+
+// quantizeError quantizes a signed prediction error for the configured NEAR
+// (CharLS quantize). For NEAR==0 it is the identity.
+func (d *jlsDecoder) quantizeError(e int) int {
+	near := d.f.near
+	if near == 0 {
+		return e
+	}
+	if e > 0 {
+		return (e + near) / (2*near + 1)
+	}
+	return -((near - e) / (2*near + 1))
 }
 
 // encodeRunInterruption encodes the sample that ended a run (inverse of
 // decodeRunInterruption).
-func (d *jlsDecoder) encodeRunInterruption(w *jlsBitWriter, ra, rb, sample int) {
+func (d *jlsDecoder) encodeRunInterruption(w *jlsBitWriter, ra, rb, sample int) int {
 	var q, nRItype, px, sign int
 	if abs(ra-rb) <= d.f.near {
 		q, nRItype, px, sign = 366, 1, ra, 1
@@ -109,7 +127,7 @@ func (d *jlsDecoder) encodeRunInterruption(w *jlsBitWriter, ra, rb, sample int) 
 			sign = -1
 		}
 	}
-	errval := sign * (sample - px)
+	errval := d.quantizeError(sign * (sample - px))
 	half := d.range_ / 2
 	if errval < -half {
 		errval += d.range_
@@ -159,9 +177,15 @@ func (d *jlsDecoder) encodeRunInterruption(w *jlsBitWriter, ra, rb, sample int) 
 		d.nn[q] >>= 1
 	}
 	d.n[q]++
+	// The decoder reconstructs the interrupting sample from px and the signed
+	// error; return it so the encoder feeds reconstructed neighbors.
+	return d.computeRecon(px, sign*errval)
 }
 
-// encodePlane encodes one component plane (NEAR=0) using regular + run mode.
+// encodePlane encodes one component plane using regular + run mode. Each encoded
+// sample's slot in plane is overwritten with the value the decoder reconstructs,
+// so subsequent samples use reconstructed neighbors (required for near-lossless;
+// a no-op for NEAR==0 where reconstructed == original).
 func (d *jlsDecoder) encodePlane(w *jlsBitWriter, plane []int) {
 	W, H := d.f.width, d.f.height
 	d.runIndex = 0
@@ -221,7 +245,7 @@ func (d *jlsDecoder) encodePlane(w *jlsBitWriter, plane []int) {
 			} else if px > d.f.maxval {
 				px = d.f.maxval
 			}
-			d.encodeRegular(w, q, sign, px, cur[x])
+			cur[x] = d.encodeRegular(w, q, sign, px, cur[x])
 			x++
 		}
 		rcLeft = lineRb0
@@ -232,10 +256,14 @@ func (d *jlsDecoder) encodePlane(w *jlsBitWriter, plane []int) {
 // encodeRun encodes a run starting at x (inverse of decodeRun).
 func (d *jlsDecoder) encodeRun(w *jlsBitWriter, cur, prev []int, y, ra, x, W int) int {
 	runVal := ra
-	// measure run length: samples equal to runVal (NEAR=0) up to end of line.
+	// measure run length: samples within NEAR of runVal up to end of line. Every
+	// run sample reconstructs to runVal, so write that back as the neighbor value.
 	runLen := 0
-	for x+runLen < W && cur[x+runLen] == runVal {
+	for x+runLen < W && abs(cur[x+runLen]-runVal) <= d.f.near {
 		runLen++
+	}
+	for i := 0; i < runLen; i++ {
+		cur[x+i] = runVal
 	}
 	remaining := W - x
 	reachedEOL := x+runLen == W
@@ -265,18 +293,22 @@ func (d *jlsDecoder) encodeRun(w *jlsBitWriter, cur, prev []int, y, ra, x, W int
 	if y > 0 {
 		rb = prev[pos]
 	}
-	d.encodeRunInterruption(w, runVal, rb, cur[pos])
+	cur[pos] = d.encodeRunInterruption(w, runVal, rb, cur[pos])
 	if d.runIndex > 0 {
 		d.runIndex--
 	}
 	return pos + 1
 }
 
-// encodeJLS encodes raw samples (LE if precision>8) as lossless JPEG-LS.
-func encodeJLS(raw []byte, width, height, samples, precision int) ([]byte, error) {
+// encodeJLS encodes raw samples (LE if precision>8) as JPEG-LS. NEAR==0 yields
+// lossless output; NEAR>0 yields near-lossless output with the given error bound.
+func encodeJLS(raw []byte, width, height, samples, precision, near int) ([]byte, error) {
 	// Single-component only: multi-component ILV=0 is not validated against the
 	// reference and charls rejects it, so it is left to charls.
 	if width <= 0 || height <= 0 || samples != 1 || precision < 2 || precision > 16 {
+		return nil, errJLSUnsupported
+	}
+	if near < 0 {
 		return nil, errJLSUnsupported
 	}
 	bps := 1
@@ -286,7 +318,7 @@ func encodeJLS(raw []byte, width, height, samples, precision int) ([]byte, error
 	if width*height*samples*bps != len(raw) {
 		return nil, errJLSUnsupported
 	}
-	f := jlsFrame{precision: precision, width: width, height: height, near: 0, ilv: 0}
+	f := jlsFrame{precision: precision, width: width, height: height, near: near, ilv: 0}
 	f.comps = make([]jlsComponent, samples)
 	for c := range f.comps {
 		f.comps[c] = jlsComponent{id: byte(c + 1), h: 1, v: 1}
@@ -304,7 +336,7 @@ func encodeJLS(raw []byte, width, height, samples, precision int) ([]byte, error
 	for c := 0; c < samples; c++ {
 		sos = append(sos, byte(c+1), 0x00)
 	}
-	sos = append(sos, 0x00, 0x00, 0x00) // NEAR=0, ILV=0, point transform=0
+	sos = append(sos, byte(near), 0x00, 0x00) // NEAR, ILV=0, point transform=0
 	out = appendJLSMarker(out, jlsSOS, sos)
 
 	// planes

--- a/codecs/jpegls/gojpegls_golden_test.go
+++ b/codecs/jpegls/gojpegls_golden_test.go
@@ -55,6 +55,145 @@ func TestGoJLSLosslessMatchesCharls(t *testing.T) {
 	}
 }
 
+// TestGoJLSNearLosslessMatchesCharls proves the pure-Go near-lossless (.81)
+// decoder is byte-for-byte identical to charls. The stream is produced by the
+// charls encoder (NEAR=1); decoding is deterministic given the stream, so the
+// two decoders must agree exactly even though the encode itself is lossy.
+func TestGoJLSNearLosslessMatchesCharls(t *testing.T) {
+	t.Cleanup(func() { SetBackend(nil) })
+	for _, tc := range []struct{ w, h, p int }{
+		{16, 16, 8}, {40, 30, 8}, {50, 40, 12}, {64, 64, 16}, {33, 17, 10},
+	} {
+		bps := 1
+		if tc.p > 8 {
+			bps = 2
+		}
+		maxv := (1 << tc.p) - 1
+		raw := make([]byte, tc.w*tc.h*bps)
+		for i := 0; i < tc.w*tc.h; i++ {
+			v := (i*7 + (i*i)%29 + (i*i*i)%17) % (maxv + 1)
+			if bps == 1 {
+				raw[i] = byte(v)
+			} else {
+				raw[i*2] = byte(v)
+				raw[i*2+1] = byte(v >> 8)
+			}
+		}
+
+		// Encode a NEAR=1 stream with charls.
+		if err := UseBackend("charls"); err != nil {
+			t.Skipf("charls unavailable: %v", err)
+		}
+		var enc []byte
+		var encSize int
+		if err := JLSencode(raw, uint16(tc.w), uint16(tc.h), 1, uint16(tc.p), &enc, &encSize, true); err != nil {
+			t.Fatalf("p%d charls near-lossless encode: %v", tc.p, err)
+		}
+		enc = enc[:encSize]
+
+		f, _, err := parseJLS(enc)
+		if err != nil {
+			t.Fatalf("p%d parse charls near-lossless stream: %v", tc.p, err)
+		}
+		if f.near == 0 {
+			t.Fatalf("p%d expected NEAR>0 stream from charls", tc.p)
+		}
+		size := f.width * f.height * len(f.comps) * bps
+
+		decode := func(backend string) []byte {
+			if err := UseBackend(backend); err != nil {
+				t.Skipf("backend %s unavailable: %v", backend, err)
+			}
+			out := make([]byte, size)
+			if err := JLSdecode(enc, uint32(len(enc)), out); err != nil {
+				t.Fatalf("p%d %s decode: %v", tc.p, backend, err)
+			}
+			return out
+		}
+		want := decode("charls")
+		got := decode("gojpegls")
+		if !bytes.Equal(want, got) {
+			n, first := 0, -1
+			for i := range want {
+				if want[i] != got[i] {
+					if first < 0 {
+						first = i
+					}
+					n++
+				}
+			}
+			t.Fatalf("p%d pure-Go near-lossless decode differs from charls in %d/%d bytes (first at %d: got %d want %d)",
+				tc.p, n, len(want), first, got[first], want[first])
+		}
+	}
+}
+
+// TestGoJLSNearLosslessEncodeDecodesInCharls confirms the pure-Go near-lossless
+// encoder emits standard-conformant output: charls must decode the stream to
+// exactly the same pixels the pure-Go decoder produces (both decoders are
+// deterministic given the stream), and every pixel must be within NEAR of the
+// original (the near-lossless guarantee).
+func TestGoJLSNearLosslessEncodeDecodesInCharls(t *testing.T) {
+	t.Cleanup(func() { SetBackend(nil) })
+	const near = 1
+	for _, tc := range []struct{ w, h, p int }{
+		{16, 16, 8}, {40, 30, 8}, {50, 40, 12}, {64, 64, 16}, {33, 17, 10},
+	} {
+		bps := 1
+		if tc.p > 8 {
+			bps = 2
+		}
+		maxv := (1 << tc.p) - 1
+		raw := make([]byte, tc.w*tc.h*bps)
+		for i := 0; i < tc.w*tc.h; i++ {
+			v := (i*7 + (i*i)%29 + (i*i*i)%17) % (maxv + 1)
+			if bps == 1 {
+				raw[i] = byte(v)
+			} else {
+				raw[i*2] = byte(v)
+				raw[i*2+1] = byte(v >> 8)
+			}
+		}
+		enc, err := encodeJLS(raw, tc.w, tc.h, 1, tc.p, near)
+		if err != nil {
+			t.Fatalf("p%d pure-Go near-lossless encode: %v", tc.p, err)
+		}
+
+		// Pure-Go decode of our own stream (the reference reconstruction).
+		SetBackend(nil)
+		mine := make([]byte, len(raw))
+		if err := decodeJLSInto(enc, mine); err != nil {
+			t.Fatalf("p%d pure-Go decode of pure-Go output: %v", tc.p, err)
+		}
+
+		// charls must decode the same stream to identical pixels.
+		if err := UseBackend("charls"); err != nil {
+			t.Skipf("charls unavailable: %v", err)
+		}
+		theirs := make([]byte, len(raw))
+		if err := JLSdecode(enc, uint32(len(enc)), theirs); err != nil {
+			t.Fatalf("p%d charls decode of pure-Go output: %v", tc.p, err)
+		}
+		if !bytes.Equal(mine, theirs) {
+			t.Fatalf("p%d charls decode of pure-Go near-lossless stream differs from pure-Go decode", tc.p)
+		}
+
+		// Near-lossless guarantee: |original - reconstructed| <= NEAR.
+		for i := 0; i < tc.w*tc.h; i++ {
+			var o, g int
+			if bps == 1 {
+				o, g = int(raw[i]), int(theirs[i])
+			} else {
+				o = int(raw[i*2]) | int(raw[i*2+1])<<8
+				g = int(theirs[i*2]) | int(theirs[i*2+1])<<8
+			}
+			if d := o - g; d < -near || d > near {
+				t.Fatalf("p%d sample %d: got %d, want within %d of %d", tc.p, i, g, near, o)
+			}
+		}
+	}
+}
+
 // TestGoJLSEncodeDecodesInCharls confirms the pure-Go lossless JPEG-LS encoder
 // emits standard-conformant output by decoding it with charls (exact round trip).
 func TestGoJLSEncodeDecodesInCharls(t *testing.T) {
@@ -77,7 +216,7 @@ func TestGoJLSEncodeDecodesInCharls(t *testing.T) {
 				raw[i*2+1] = byte(v >> 8)
 			}
 		}
-		enc, err := encodeJLS(raw, tc.w, tc.h, 1, tc.p)
+		enc, err := encodeJLS(raw, tc.w, tc.h, 1, tc.p, 0)
 		if err != nil {
 			t.Fatalf("p%d encode: %v", tc.p, err)
 		}

--- a/codecs/jpegls/gojpegls_scan.go
+++ b/codecs/jpegls/gojpegls_scan.go
@@ -122,12 +122,6 @@ func parseJLSScan(seg []byte, f *jlsFrame) error {
 	if f.ilv != 0 {
 		return errJLSUnsupported // interleaved scans not yet supported
 	}
-	if f.near != 0 {
-		// Near-lossless (.81): a context-modeling edge case still diverges from
-		// the reference, so defer to charls when available rather than risk
-		// silently wrong pixels.
-		return errJLSUnsupported
-	}
 	return nil
 }
 
@@ -367,14 +361,14 @@ func (gojpeglsBackend) DecodeContext(_ context.Context, encoded []byte, output [
 }
 
 func (gojpeglsBackend) Encode(raw []byte, width uint16, height uint16, samples uint16, bitsa uint16, nearLossless bool) ([]byte, error) {
+	// NEAR=1 matches the charls backend's near-lossless setting; NEAR=0 is
+	// lossless. encodeJLS errors for unsupported geometry (e.g. multi-component),
+	// which is correct — better than producing an invalid stream that reports success.
+	near := 0
 	if nearLossless {
-		// No pure-Go near-lossless encoder; error rather than emit raw bytes as
-		// a fake compressed stream (charls handles this when built with -tags charls).
-		return nil, errJLSUnsupported
+		near = 1
 	}
-	// encodeJLS errors for unsupported geometry (e.g. multi-component), which is
-	// correct — better than producing an invalid stream that reports success.
-	return encodeJLS(raw, int(width), int(height), int(samples), int(bitsa))
+	return encodeJLS(raw, int(width), int(height), int(samples), int(bitsa), near)
 }
 
 func registerPureGoBackend() {

--- a/codecs/jpegls/gojpegls_scan.go
+++ b/codecs/jpegls/gojpegls_scan.go
@@ -122,6 +122,12 @@ func parseJLSScan(seg []byte, f *jlsFrame) error {
 	if f.ilv != 0 {
 		return errJLSUnsupported // interleaved scans not yet supported
 	}
+	// tail[2] is the point-transform field (Al). The decoder does not apply a
+	// point transform, so a non-zero value would silently yield wrong pixels —
+	// reject it as unsupported.
+	if tail[2] != 0 {
+		return errJLSUnsupported
+	}
 	return nil
 }
 

--- a/codecs/jpegls/gojpegls_test.go
+++ b/codecs/jpegls/gojpegls_test.go
@@ -72,13 +72,27 @@ func TestGoJLSDecodesLosslessFixture(t *testing.T) {
 	}
 }
 
-// TestGoJLSDefersNearLossless confirms the pure-Go decoder reports near-lossless
-// as unsupported (so charls handles it), rather than producing wrong pixels.
-func TestGoJLSDefersNearLossless(t *testing.T) {
+// TestGoJLSDecodesNearLossless confirms the pure-Go decoder now handles a
+// near-lossless (.81) stream: it parses the NEAR>0 scan header and decodes a
+// full-size frame without error. Byte-exact fidelity against charls is covered
+// by TestGoJLSNearLosslessMatchesCharls (cgo-tagged).
+func TestGoJLSDecodesNearLossless(t *testing.T) {
 	dcm := loadDCM(t, "../../testdata/cornerstone-CTImage-jpegls-lossy.dcm")
 	frame := extractFirstFrame(t, dcm)
-	if _, _, err := parseJLS(frame); err == nil {
-		t.Fatal("expected near-lossless to be reported unsupported by the pure-Go decoder")
+	f, _, err := parseJLS(frame)
+	if err != nil {
+		t.Fatalf("parseJLS near-lossless: %v", err)
+	}
+	if f.near == 0 {
+		t.Fatal("expected NEAR>0 for the lossy fixture")
+	}
+	bps := 1
+	if f.precision > 8 {
+		bps = 2
+	}
+	out := make([]byte, f.width*f.height*len(f.comps)*bps)
+	if err := decodeJLSInto(frame, out); err != nil {
+		t.Fatalf("decode near-lossless: %v", err)
 	}
 }
 
@@ -118,7 +132,7 @@ func TestGoJLSEncodeRoundTrip(t *testing.T) {
 				raw[i*2+1] = byte(v >> 8)
 			}
 		}
-		enc, err := encodeJLS(raw, tc.w, tc.h, 1, tc.p)
+		enc, err := encodeJLS(raw, tc.w, tc.h, 1, tc.p, 0)
 		if err != nil {
 			t.Fatalf("p%d encode: %v", tc.p, err)
 		}
@@ -132,10 +146,63 @@ func TestGoJLSEncodeRoundTrip(t *testing.T) {
 	}
 }
 
-// TestGoJLSEncodeRejectsUnsupported confirms multi-component and near-lossless
-// encode are reported unsupported rather than producing invalid output.
+// TestGoJLSEncodeRejectsUnsupported confirms multi-component encode is reported
+// unsupported rather than producing invalid output.
 func TestGoJLSEncodeRejectsUnsupported(t *testing.T) {
-	if _, err := encodeJLS(make([]byte, 3*4*4), 4, 4, 3, 8); err == nil {
+	if _, err := encodeJLS(make([]byte, 3*4*4), 4, 4, 3, 8, 0); err == nil {
 		t.Fatal("expected 3-component encode to be unsupported")
+	}
+}
+
+// TestGoJLSNearLosslessEncodeRoundTrip encodes synthetic images with the pure-Go
+// near-lossless encoder (NEAR=1) and decodes them with the pure-Go decoder,
+// requiring every sample to be within NEAR of the original (the near-lossless
+// guarantee) and the decode to reproduce the encoder's own reconstruction.
+func TestGoJLSNearLosslessEncodeRoundTrip(t *testing.T) {
+	const near = 1
+	for _, tc := range []struct{ w, h, p int }{
+		{16, 16, 8}, {40, 30, 8}, {50, 40, 12}, {64, 64, 16}, {33, 17, 10},
+	} {
+		bps := 1
+		if tc.p > 8 {
+			bps = 2
+		}
+		maxv := (1 << tc.p) - 1
+		raw := make([]byte, tc.w*tc.h*bps)
+		sample := func(i int) int {
+			if bps == 1 {
+				return int(raw[i])
+			}
+			return int(raw[i*2]) | int(raw[i*2+1])<<8
+		}
+		for i := 0; i < tc.w*tc.h; i++ {
+			v := (i*7 + (i*i)%29 + (i*i*i)%17) % (maxv + 1)
+			if bps == 1 {
+				raw[i] = byte(v)
+			} else {
+				raw[i*2] = byte(v)
+				raw[i*2+1] = byte(v >> 8)
+			}
+		}
+		enc, err := encodeJLS(raw, tc.w, tc.h, 1, tc.p, near)
+		if err != nil {
+			t.Fatalf("p%d near-lossless encode: %v", tc.p, err)
+		}
+		out := make([]byte, len(raw))
+		if err := decodeJLSInto(enc, out); err != nil {
+			t.Fatalf("p%d decode: %v", tc.p, err)
+		}
+		for i := 0; i < tc.w*tc.h; i++ {
+			orig := sample(i)
+			var got int
+			if bps == 1 {
+				got = int(out[i])
+			} else {
+				got = int(out[i*2]) | int(out[i*2+1])<<8
+			}
+			if d := orig - got; d < -near || d > near {
+				t.Fatalf("p%d sample %d: got %d, want within %d of %d", tc.p, i, got, near, orig)
+			}
+		}
 	}
 }

--- a/media/dicom_object_test.go
+++ b/media/dicom_object_test.go
@@ -149,7 +149,7 @@ func Test_dcmObj_ChangeTransferSyntax(t *testing.T) {
 			name:     "Should change transfer syntax to JPEGLSNearLossless",
 			fileName: "../testdata/test2.dcm",
 			args:     args{transfersyntax.JPEGLSNearLossless},
-			wantErr:  true, // no pure-Go JPEG-LS near-lossless encoder
+			wantErr:  false, // pure-Go JPEG-LS near-lossless encoder
 		},
 		{
 			name:     "Should change transfer syntax to JPEG2000Lossless",


### PR DESCRIPTION
## Summary
Completes pure-Go JPEG-LS by adding **near-lossless (.81)** support — both decode and encode — closing the last functional gap left open after #14.

## The bug (decode)
In CharLS `do_regular` the k==0 bias-sign error correction is applied through `get_error_correction(near_lossless)`, which returns `0` whenever its argument is nonzero. So the correction applies in **pure-lossless mode only**. The pure-Go decoder applied it unconditionally; in near-lossless mode every k==0 sample could flip the decoded error, cascading through the A/B context state and silently diverging from the reference. The fix is one guard:

```go
if k == 0 && d.f.near == 0 && 2*d.b[q]+d.n[q]-1 < 0 {
```

It never affected lossless because NEAR==0 makes both behaviors identical.

## Encoder
With decode correct, the encoder gains near-lossless: quantize the prediction error (CharLS `quantize`), gate the same flip, and feed **reconstructed** (not original) neighbors by writing each reconstructed sample back into the plane across regular / run / run-interruption modes. `encodeJLS` takes a NEAR parameter; the backend maps the `nearLossless` flag to NEAR=1 (matching charls).

## Validation (vs charls 2.4.3, cgo)
- **Decode** of charls-encoded NEAR=1 streams: byte-exact across 8/10/12/16-bit.
- **Encode**: charls decodes our stream to the *same* pixels as our own decoder, and every pixel is within NEAR of the original.
- Pure-Go near-lossless encode round-trip (no-cgo); full no-cgo `./...`; cgo jpegls + media; gofmt; vet — all green.
- Decoder remains fuzz-clean (16M execs, no crashes).

Un-gates near-lossless in `parseJLSScan` and flips the `JPEGLSNearLossless` media transcode test to expect success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)