### PR TITLE
feat(jpegls): pure-Go multi-component interleaved (ILV=1/2) JPEG-LS decode + encode

### DIFF
--- a/codecs/jpegls/gojpegls_encode.go
+++ b/codecs/jpegls/gojpegls_encode.go
@@ -182,74 +182,106 @@ func (d *jlsDecoder) encodeRunInterruption(w *jlsBitWriter, ra, rb, sample int) 
 	return d.computeRecon(px, sign*errval)
 }
 
-// encodePlane encodes one component plane using regular + run mode. Each encoded
-// sample's slot in plane is overwritten with the value the decoder reconstructs,
-// so subsequent samples use reconstructed neighbors (required for near-lossless;
-// a no-op for NEAR==0 where reconstructed == original).
+// encodeScalarLine encodes one scan line of a single component. cur holds the
+// input samples and is overwritten in place with the values the decoder will
+// reconstruct (so later samples — and, in near-lossless, later lines — use
+// reconstructed neighbors); prev is the reconstructed line above; rcLeft is Rc at
+// line start. Returns rcLeft for the next line. Context state and d.runIndex are
+// shared; line-interleaved scans save/restore d.runIndex per component.
+func (d *jlsDecoder) encodeScalarLine(w *jlsBitWriter, cur, prev []int, y, rcLeft int) int {
+	W := d.f.width
+	lineRb0 := 0
+	if y > 0 {
+		lineRb0 = prev[0]
+	}
+	x := 0
+	for x < W {
+		var a, b, c, dd int
+		if y == 0 {
+			b, c, dd = 0, 0, 0
+		} else {
+			b = prev[x]
+			if x+1 < W {
+				dd = prev[x+1]
+			} else {
+				dd = b
+			}
+		}
+		if x == 0 {
+			a = lineRb0
+			c = rcLeft
+		} else {
+			a = cur[x-1]
+			if y > 0 {
+				c = prev[x-1]
+			}
+		}
+
+		q1 := d.quantize(dd - b)
+		q2 := d.quantize(b - c)
+		q3 := d.quantize(c - a)
+
+		if q1 == 0 && q2 == 0 && q3 == 0 {
+			x = d.encodeRun(w, cur, prev, y, a, x, W)
+			continue
+		}
+		q := 81*q1 + 9*q2 + q3
+		sign := 1
+		if q < 0 {
+			q = -q
+			sign = -1
+		}
+		px := predict(a, b, c)
+		if sign > 0 {
+			px += d.c[q]
+		} else {
+			px -= d.c[q]
+		}
+		if px < 0 {
+			px = 0
+		} else if px > d.f.maxval {
+			px = d.f.maxval
+		}
+		cur[x] = d.encodeRegular(w, q, sign, px, cur[x])
+		x++
+	}
+	return lineRb0
+}
+
+// encodePlane encodes one component plane (ILV=0) using regular + run mode.
 func (d *jlsDecoder) encodePlane(w *jlsBitWriter, plane []int) {
 	W, H := d.f.width, d.f.height
 	d.runIndex = 0
 	prev := make([]int, W)
 	rcLeft := 0
 	for y := 0; y < H; y++ {
-		lineRb0 := 0
-		if y > 0 {
-			lineRb0 = prev[0]
-		}
 		cur := plane[y*W : y*W+W]
-		x := 0
-		for x < W {
-			var a, b, c, dd int
-			if y == 0 {
-				b, c, dd = 0, 0, 0
-			} else {
-				b = prev[x]
-				if x+1 < W {
-					dd = prev[x+1]
-				} else {
-					dd = b
-				}
-			}
-			if x == 0 {
-				a = lineRb0
-				c = rcLeft
-			} else {
-				a = cur[x-1]
-				if y > 0 {
-					c = prev[x-1]
-				}
-			}
-
-			q1 := d.quantize(dd - b)
-			q2 := d.quantize(b - c)
-			q3 := d.quantize(c - a)
-
-			if q1 == 0 && q2 == 0 && q3 == 0 {
-				x = d.encodeRun(w, cur, prev, y, a, x, W)
-				continue
-			}
-			q := 81*q1 + 9*q2 + q3
-			sign := 1
-			if q < 0 {
-				q = -q
-				sign = -1
-			}
-			px := predict(a, b, c)
-			if sign > 0 {
-				px += d.c[q]
-			} else {
-				px -= d.c[q]
-			}
-			if px < 0 {
-				px = 0
-			} else if px > d.f.maxval {
-				px = d.f.maxval
-			}
-			cur[x] = d.encodeRegular(w, q, sign, px, cur[x])
-			x++
-		}
-		rcLeft = lineRb0
+		rcLeft = d.encodeScalarLine(w, cur, prev, y, rcLeft)
 		copy(prev, cur)
+	}
+}
+
+// encodeLineInterleaved encodes multiple component planes as an ILV=1
+// (line-interleaved) scan: for each line, every component's line is encoded in
+// turn. Each component keeps its own reconstructed line above and run index; the
+// regular/run context statistics are shared (CharLS encode_lines, line mode).
+func (d *jlsDecoder) encodeLineInterleaved(w *jlsBitWriter, planes [][]int) {
+	W, H := d.f.width, d.f.height
+	nc := len(planes)
+	prev := make([][]int, nc)
+	rcLeft := make([]int, nc)
+	runIdx := make([]int, nc)
+	for c := 0; c < nc; c++ {
+		prev[c] = make([]int, W)
+	}
+	for y := 0; y < H; y++ {
+		for c := 0; c < nc; c++ {
+			cur := planes[c][y*W : y*W+W]
+			d.runIndex = runIdx[c]
+			rcLeft[c] = d.encodeScalarLine(w, cur, prev[c], y, rcLeft[c])
+			runIdx[c] = d.runIndex
+			copy(prev[c], cur)
+		}
 	}
 }
 
@@ -303,9 +335,9 @@ func (d *jlsDecoder) encodeRun(w *jlsBitWriter, cur, prev []int, y, ra, x, W int
 // encodeJLS encodes raw samples (LE if precision>8) as JPEG-LS. NEAR==0 yields
 // lossless output; NEAR>0 yields near-lossless output with the given error bound.
 func encodeJLS(raw []byte, width, height, samples, precision, near int) ([]byte, error) {
-	// Single-component only: multi-component ILV=0 is not validated against the
-	// reference and charls rejects it, so it is left to charls.
-	if width <= 0 || height <= 0 || samples != 1 || precision < 2 || precision > 16 {
+	// Single-component is written non-interleaved (ILV=0); multi-component is
+	// written line-interleaved (ILV=1), matching the charls backend.
+	if width <= 0 || height <= 0 || samples < 1 || samples > 255 || precision < 2 || precision > 16 {
 		return nil, errJLSUnsupported
 	}
 	// NEAR is written as a single byte in the SOS scan header and must not exceed
@@ -322,7 +354,11 @@ func encodeJLS(raw []byte, width, height, samples, precision, near int) ([]byte,
 	if width*height*samples*bps != len(raw) {
 		return nil, errJLSUnsupported
 	}
-	f := jlsFrame{precision: precision, width: width, height: height, near: near, ilv: 0}
+	ilv := 0
+	if samples > 1 {
+		ilv = 1 // line-interleaved for multi-component (matches charls)
+	}
+	f := jlsFrame{precision: precision, width: width, height: height, near: near, ilv: ilv}
 	f.comps = make([]jlsComponent, samples)
 	for c := range f.comps {
 		f.comps[c] = jlsComponent{id: byte(c + 1), h: 1, v: 1}
@@ -340,7 +376,7 @@ func encodeJLS(raw []byte, width, height, samples, precision, near int) ([]byte,
 	for c := 0; c < samples; c++ {
 		sos = append(sos, byte(c+1), 0x00)
 	}
-	sos = append(sos, byte(near), 0x00, 0x00) // NEAR, ILV=0, point transform=0
+	sos = append(sos, byte(near), byte(ilv), 0x00) // NEAR, ILV, point transform=0
 	out = appendJLSMarker(out, jlsSOS, sos)
 
 	// planes
@@ -359,13 +395,12 @@ func encodeJLS(raw []byte, width, height, samples, precision, near int) ([]byte,
 		}
 	}
 
-	// samples == 1 here (multi-component is rejected above), so this encodes the
-	// single component's plane; encodePlane resets only the run index, mirroring
-	// the decoder's decodePlane.
 	d := newJLSDecoder(&f, nil)
 	w := &jlsBitWriter{out: out}
-	for c := 0; c < samples; c++ {
-		d.encodePlane(w, planes[c])
+	if samples == 1 {
+		d.encodePlane(w, planes[0])
+	} else {
+		d.encodeLineInterleaved(w, planes)
 	}
 	w.flush()
 	out = w.out

--- a/codecs/jpegls/gojpegls_encode.go
+++ b/codecs/jpegls/gojpegls_encode.go
@@ -336,8 +336,15 @@ func (d *jlsDecoder) encodeRun(w *jlsBitWriter, cur, prev []int, y, ra, x, W int
 // lossless output; NEAR>0 yields near-lossless output with the given error bound.
 func encodeJLS(raw []byte, width, height, samples, precision, near int) ([]byte, error) {
 	// Single-component is written non-interleaved (ILV=0); multi-component is
-	// written line-interleaved (ILV=1), matching the charls backend.
-	if width <= 0 || height <= 0 || samples < 1 || samples > 255 || precision < 2 || precision > 16 {
+	// written line-interleaved (ILV=1), matching the charls backend. width/height
+	// are written into 16-bit SOF fields, so they must fit in 1..0xFFFF.
+	if width <= 0 || width > 0xFFFF || height <= 0 || height > 0xFFFF ||
+		samples < 1 || samples > 255 || precision < 2 || precision > 16 {
+		return nil, errJLSUnsupported
+	}
+	// Cap total samples to the same bound as the decoder to avoid huge
+	// allocations. int64 avoids overflow on 32-bit builds.
+	if int64(width)*int64(height)*int64(samples) > maxJLSSamples {
 		return nil, errJLSUnsupported
 	}
 	// NEAR is written as a single byte in the SOS scan header and must not exceed
@@ -351,7 +358,7 @@ func encodeJLS(raw []byte, width, height, samples, precision, near int) ([]byte,
 	if precision > 8 {
 		bps = 2
 	}
-	if width*height*samples*bps != len(raw) {
+	if int64(width)*int64(height)*int64(samples)*int64(bps) != int64(len(raw)) {
 		return nil, errJLSUnsupported
 	}
 	ilv := 0

--- a/codecs/jpegls/gojpegls_golden_test.go
+++ b/codecs/jpegls/gojpegls_golden_test.go
@@ -55,6 +55,194 @@ func TestGoJLSLosslessMatchesCharls(t *testing.T) {
 	}
 }
 
+// TestGoJLSMultiComponentEncodeDecodesInCharls confirms the pure-Go multi-
+// component (line-interleaved) encoder emits standard-conformant output: charls
+// must decode the stream to exactly the same pixels the pure-Go decoder produces,
+// and every pixel must be within NEAR of the original.
+func TestGoJLSMultiComponentEncodeDecodesInCharls(t *testing.T) {
+	t.Cleanup(func() { SetBackend(nil) })
+	for _, tc := range []struct {
+		w, h, comps, p, near int
+	}{
+		{16, 16, 3, 8, 0}, {20, 12, 3, 8, 1}, {17, 9, 3, 12, 0},
+		{32, 8, 3, 16, 2}, {10, 10, 4, 8, 0}, {13, 11, 4, 12, 1},
+	} {
+		bps := 1
+		if tc.p > 8 {
+			bps = 2
+		}
+		maxv := (1 << tc.p) - 1
+		n := tc.w * tc.h * tc.comps
+		raw := make([]byte, n*bps)
+		for i := 0; i < n; i++ {
+			v := (i*7 + (i*i)%29 + (i%tc.comps)*11) % (maxv + 1)
+			if bps == 1 {
+				raw[i] = byte(v)
+			} else {
+				raw[i*2] = byte(v)
+				raw[i*2+1] = byte(v >> 8)
+			}
+		}
+		enc, err := encodeJLS(raw, tc.w, tc.h, tc.comps, tc.p, tc.near)
+		if err != nil {
+			t.Fatalf("%dc p%d near%d pure-Go encode: %v", tc.comps, tc.p, tc.near, err)
+		}
+
+		SetBackend(nil)
+		mine := make([]byte, len(raw))
+		if err := decodeJLSInto(enc, mine); err != nil {
+			t.Fatalf("%dc pure-Go decode of own output: %v", tc.comps, err)
+		}
+
+		if err := UseBackend("charls"); err != nil {
+			t.Skipf("charls unavailable: %v", err)
+		}
+		theirs := make([]byte, len(raw))
+		if err := JLSdecode(enc, uint32(len(enc)), theirs); err != nil {
+			t.Fatalf("%dc charls decode of pure-Go output: %v", tc.comps, err)
+		}
+		if !bytes.Equal(mine, theirs) {
+			t.Fatalf("%dc p%d near%d charls decode differs from pure-Go decode", tc.comps, tc.p, tc.near)
+		}
+		for i := 0; i < n; i++ {
+			var o, g int
+			if bps == 1 {
+				o, g = int(raw[i]), int(theirs[i])
+			} else {
+				o = int(raw[i*2]) | int(raw[i*2+1])<<8
+				g = int(theirs[i*2]) | int(theirs[i*2+1])<<8
+			}
+			if d := o - g; d < -tc.near || d > tc.near {
+				t.Fatalf("%dc p%d near%d sample %d: got %d want within %d of %d", tc.comps, tc.p, tc.near, i, g, tc.near, o)
+			}
+		}
+	}
+}
+
+// TestGoJLSLineInterleavedMatchesCharls proves the pure-Go ILV=1 (line-
+// interleaved) multi-component decoder is byte-for-byte identical to charls. The
+// charls encoder uses INTERLEAVE_MODE_LINE for multi-component input, so this
+// produces line-interleaved streams across bit depths and NEAR values.
+func TestGoJLSLineInterleavedMatchesCharls(t *testing.T) {
+	t.Cleanup(func() { SetBackend(nil) })
+	for _, tc := range []struct {
+		w, h, comps, p, near int
+	}{
+		{16, 16, 3, 8, 0}, {20, 12, 3, 8, 1}, {17, 9, 3, 12, 0},
+		{32, 8, 3, 16, 2}, {10, 10, 4, 8, 0}, {13, 11, 4, 8, 1},
+	} {
+		bps := 1
+		if tc.p > 8 {
+			bps = 2
+		}
+		maxv := (1 << tc.p) - 1
+		n := tc.w * tc.h * tc.comps
+		raw := make([]byte, n*bps)
+		for i := 0; i < n; i++ {
+			v := (i*7 + (i*i)%29 + (i%tc.comps)*11) % (maxv + 1)
+			if bps == 1 {
+				raw[i] = byte(v)
+			} else {
+				raw[i*2] = byte(v)
+				raw[i*2+1] = byte(v >> 8)
+			}
+		}
+
+		if err := UseBackend("charls"); err != nil {
+			t.Skipf("charls unavailable: %v", err)
+		}
+		var enc []byte
+		var encSize int
+		if err := JLSencode(raw, uint16(tc.w), uint16(tc.h), uint16(tc.comps), uint16(tc.p), &enc, &encSize, tc.near != 0); err != nil {
+			t.Fatalf("%dc p%d near%d charls encode: %v", tc.comps, tc.p, tc.near, err)
+		}
+		enc = enc[:encSize]
+
+		f, _, err := parseJLS(enc)
+		if err != nil {
+			t.Fatalf("%dc parse charls stream: %v", tc.comps, err)
+		}
+		if f.ilv != 1 || len(f.comps) != tc.comps {
+			t.Fatalf("%dc expected ILV=1 with %d comps, got ilv=%d comps=%d", tc.comps, tc.comps, f.ilv, len(f.comps))
+		}
+
+		decode := func(backend string) []byte {
+			if err := UseBackend(backend); err != nil {
+				t.Skipf("backend %s unavailable: %v", backend, err)
+			}
+			out := make([]byte, len(raw))
+			if err := JLSdecode(enc, uint32(len(enc)), out); err != nil {
+				t.Fatalf("%dc %s decode: %v", tc.comps, backend, err)
+			}
+			return out
+		}
+		want := decode("charls")
+		got := decode("gojpegls")
+		if !bytes.Equal(want, got) {
+			n, first := 0, -1
+			for i := range want {
+				if want[i] != got[i] {
+					if first < 0 {
+						first = i
+					}
+					n++
+				}
+			}
+			t.Fatalf("%dc p%d near%d line-interleaved decode differs in %d/%d bytes (first at %d: got %d want %d)",
+				tc.comps, tc.p, tc.near, n, len(want), first, got[first], want[first])
+		}
+	}
+}
+
+// TestGoJLSSampleInterleavedMatchesCharls proves the pure-Go ILV=2 (sample-
+// interleaved) multi-component decoder is byte-for-byte identical to charls,
+// using the real highdicom RGB fixtures (3-component, sample-interleaved).
+func TestGoJLSSampleInterleavedMatchesCharls(t *testing.T) {
+	t.Cleanup(func() { SetBackend(nil) })
+	for _, path := range []string{
+		"../../testdata/highdicom-sm_image_jpegls.dcm",
+		"../../testdata/highdicom-sm_image_jpegls_nobot.dcm",
+	} {
+		t.Run(path, func(t *testing.T) {
+			dcm := loadDCM(t, path)
+			frame := extractFirstFrame(t, dcm)
+			f, _, err := parseJLS(frame)
+			if err != nil {
+				t.Fatalf("parseJLS: %v", err)
+			}
+			if f.ilv != 2 || len(f.comps) < 2 {
+				t.Skipf("not a sample-interleaved multi-component stream (ilv=%d comps=%d)", f.ilv, len(f.comps))
+			}
+			bps := 1
+			if f.precision > 8 {
+				bps = 2
+			}
+			size := f.width * f.height * len(f.comps) * bps
+			decode := func(backend string) []byte {
+				if err := UseBackend(backend); err != nil {
+					t.Skipf("backend %s unavailable: %v", backend, err)
+				}
+				out := make([]byte, size)
+				if err := JLSdecode(frame, uint32(len(frame)), out); err != nil {
+					t.Fatalf("%s decode: %v", backend, err)
+				}
+				return out
+			}
+			want := decode("charls")
+			got := decode("gojpegls")
+			if !bytes.Equal(want, got) {
+				n := 0
+				for i := range want {
+					if want[i] != got[i] {
+						n++
+					}
+				}
+				t.Fatalf("sample-interleaved decode differs from charls in %d/%d bytes", n, len(want))
+			}
+		})
+	}
+}
+
 // TestGoJLSNearLosslessMatchesCharls proves the pure-Go near-lossless (.81)
 // decoder is byte-for-byte identical to charls. The stream is produced by the
 // charls encoder (NEAR=1); decoding is deterministic given the stream, so the

--- a/codecs/jpegls/gojpegls_scan.go
+++ b/codecs/jpegls/gojpegls_scan.go
@@ -69,7 +69,7 @@ func parseJLSFrame(seg []byte, f *jlsFrame) error {
 	if f.precision < 2 || f.precision > 16 || f.width == 0 || f.height == 0 {
 		return errJLSUnsupported
 	}
-	if nf != 1 && nf != 3 {
+	if nf < 1 || nf > 255 {
 		return errJLSUnsupported
 	}
 	if f.width*f.height*nf > maxJLSSamples {
@@ -119,8 +119,19 @@ func parseJLSScan(seg []byte, f *jlsFrame) error {
 	tail := seg[1+ns*2:]
 	f.near = int(tail[0])
 	f.ilv = int(tail[1])
-	if f.ilv != 0 {
-		return errJLSUnsupported // interleaved scans not yet supported
+	if f.ilv != 0 && f.ilv != 1 && f.ilv != 2 {
+		return errJLSUnsupported // ILV must be 0 (none), 1 (line) or 2 (sample)
+	}
+	// Non-interleaved multi-component is encoded as separate single-component
+	// scans (one SOS each), which this single-scan reader does not assemble; only
+	// single-component ILV=0 is supported.
+	if f.ilv == 0 && len(f.comps) != 1 {
+		return errJLSUnsupported
+	}
+	// Sample-interleaved coding is defined only for 3-component (triplet) or
+	// 4-component (quad) pixels (CharLS do_line(triplet/quad)).
+	if f.ilv == 2 && len(f.comps) != 3 && len(f.comps) != 4 {
+		return errJLSUnsupported
 	}
 	// tail[2] is the point-transform field (Al). The decoder does not apply a
 	// point transform, so a non-zero value would silently yield wrong pixels —
@@ -151,29 +162,288 @@ func decodeJLSInto(encoded, output []byte) error {
 	}
 
 	d := newJLSDecoder(&f, encoded[scanOff:])
-	// Non-interleaved (ILV=0): each component is a full plane, decoded in turn.
-	planes := make([][]int, nc)
-	for c := 0; c < nc; c++ {
-		planes[c] = make([]int, f.width*f.height)
-		d.decodePlane(planes[c])
-	}
-
-	// Pack component-minor interleaved, little-endian.
-	for y := 0; y < f.height; y++ {
-		for x := 0; x < f.width; x++ {
-			for c := 0; c < nc; c++ {
-				v := planes[c][y*f.width+x]
-				idx := (y*f.width+x)*nc + c
-				if bps == 1 {
-					output[idx] = byte(v)
-				} else {
-					output[idx*2] = byte(v)
-					output[idx*2+1] = byte(v >> 8)
-				}
+	switch f.ilv {
+	case 1:
+		d.decodeLineInterleaved(output, nc, bps)
+	case 2:
+		d.decodeSampleInterleaved(output, nc, bps)
+	default:
+		// Non-interleaved (ILV=0): each component is a full plane, decoded in
+		// turn, then packed pixel-interleaved (component-minor), little-endian.
+		for c := 0; c < nc; c++ {
+			plane := make([]int, f.width*f.height)
+			d.decodePlane(plane)
+			for i, v := range plane {
+				putSample(output, i*nc+c, v, bps)
 			}
 		}
 	}
 	return nil
+}
+
+// decodeScalarLine decodes one scan line of a single component into cur, using
+// prev as the reconstructed line above and rcLeft as Rc at the start of the line
+// (R[y-1][-1]). It returns the rcLeft to pass for the next line. The regular/run
+// context state and d.runIndex are shared via the decoder; line-interleaved
+// scans save/restore d.runIndex per component around this call.
+func (d *jlsDecoder) decodeScalarLine(cur, prev []int, y, rcLeft int) int {
+	W := d.f.width
+	lineRb0 := 0
+	if y > 0 {
+		lineRb0 = prev[0]
+	}
+	x := 0
+	for x < W {
+		// neighbors
+		var a, b, c, dd int
+		if y == 0 {
+			b, c, dd = 0, 0, 0
+		} else {
+			b = prev[x]
+			if x+1 < W {
+				dd = prev[x+1]
+			} else {
+				dd = b
+			}
+		}
+		if x == 0 {
+			a = lineRb0 // Ra at line start = sample above (b)
+			c = rcLeft
+		} else {
+			a = cur[x-1]
+			if y > 0 {
+				c = prev[x-1]
+			}
+		}
+
+		q1 := d.quantize(dd - b)
+		q2 := d.quantize(b - c)
+		q3 := d.quantize(c - a)
+
+		if q1 == 0 && q2 == 0 && q3 == 0 {
+			x = d.decodeRun(cur, prev, y, a, x, W)
+			continue
+		}
+
+		q := 81*q1 + 9*q2 + q3
+		sign := 1
+		if q < 0 {
+			q = -q
+			sign = -1
+		}
+		px := predict(a, b, c)
+		if sign > 0 {
+			px += d.c[q]
+		} else {
+			px -= d.c[q]
+		}
+		if px < 0 {
+			px = 0
+		} else if px > d.f.maxval {
+			px = d.f.maxval
+		}
+		cur[x] = d.decodeRegular(q, sign, px)
+		x++
+	}
+	return lineRb0
+}
+
+// putSample writes a reconstructed sample into the codec's little-endian output
+// at sample index idx (bps bytes per sample).
+func putSample(out []byte, idx, v, bps int) {
+	if bps == 1 {
+		out[idx] = byte(v)
+		return
+	}
+	out[idx*2] = byte(v)
+	out[idx*2+1] = byte(v >> 8)
+}
+
+// decodeLineInterleaved decodes an ILV=1 (line-interleaved) multi-component scan
+// directly into the pixel-interleaved output. Each component keeps its own
+// reconstructed lines and run index; the regular/run context statistics are
+// shared across components (CharLS decode_lines, interleave_mode::line).
+func (d *jlsDecoder) decodeLineInterleaved(out []byte, nc, bps int) {
+	W, H := d.f.width, d.f.height
+	prev := make([][]int, nc)
+	cur := make([][]int, nc)
+	rcLeft := make([]int, nc)
+	runIdx := make([]int, nc)
+	for c := 0; c < nc; c++ {
+		prev[c] = make([]int, W)
+		cur[c] = make([]int, W)
+	}
+	for y := 0; y < H; y++ {
+		for c := 0; c < nc; c++ {
+			d.runIndex = runIdx[c]
+			rcLeft[c] = d.decodeScalarLine(cur[c], prev[c], y, rcLeft[c])
+			runIdx[c] = d.runIndex
+		}
+		base := y * W * nc
+		for x := 0; x < W; x++ {
+			for c := 0; c < nc; c++ {
+				putSample(out, base+x*nc+c, cur[c][x], bps)
+			}
+		}
+		for c := 0; c < nc; c++ {
+			prev[c], cur[c] = cur[c], prev[c]
+		}
+	}
+}
+
+// decodeSampleInterleaved decodes an ILV=2 (sample-interleaved) multi-component
+// scan directly into the pixel-interleaved output. All components share a single
+// run index and the regular/run context statistics; a pixel enters run mode only
+// when every component's context is 0, and a run reconstructs whole pixels
+// (CharLS decode_lines + do_line(triplet/quad), interleave_mode::sample).
+func (d *jlsDecoder) decodeSampleInterleaved(out []byte, nc, bps int) {
+	W, H := d.f.width, d.f.height
+	prev := make([][]int, nc)
+	cur := make([][]int, nc)
+	rcLeft := make([]int, nc)
+	for c := 0; c < nc; c++ {
+		prev[c] = make([]int, W)
+		cur[c] = make([]int, W)
+	}
+	ra := make([]int, nc)
+	rb := make([]int, nc)
+	rc := make([]int, nc)
+	rd := make([]int, nc)
+	qs := make([]int, nc)
+	sgn := make([]int, nc)
+	lineRb0 := make([]int, nc)
+	d.runIndex = 0
+
+	for y := 0; y < H; y++ {
+		for c := 0; c < nc; c++ {
+			lineRb0[c] = 0
+			if y > 0 {
+				lineRb0[c] = prev[c][0]
+			}
+		}
+		x := 0
+		for x < W {
+			allZero := true
+			for c := 0; c < nc; c++ {
+				var a, b, cc, dd int
+				if y == 0 {
+					b, cc, dd = 0, 0, 0
+				} else {
+					b = prev[c][x]
+					if x+1 < W {
+						dd = prev[c][x+1]
+					} else {
+						dd = b
+					}
+				}
+				if x == 0 {
+					a = lineRb0[c]
+					cc = rcLeft[c]
+				} else {
+					a = cur[c][x-1]
+					if y > 0 {
+						cc = prev[c][x-1]
+					}
+				}
+				ra[c], rb[c], rc[c], rd[c] = a, b, cc, dd
+				q := 81*d.quantize(dd-b) + 9*d.quantize(b-cc) + d.quantize(cc-a)
+				s := 1
+				if q < 0 {
+					q = -q
+					s = -1
+				}
+				qs[c], sgn[c] = q, s
+				if q != 0 {
+					allZero = false
+				}
+			}
+			if allZero {
+				x = d.decodeSampleRun(cur, prev, ra, y, x, nc)
+				continue
+			}
+			for c := 0; c < nc; c++ {
+				px := predict(ra[c], rb[c], rc[c])
+				if sgn[c] > 0 {
+					px += d.c[qs[c]]
+				} else {
+					px -= d.c[qs[c]]
+				}
+				if px < 0 {
+					px = 0
+				} else if px > d.f.maxval {
+					px = d.f.maxval
+				}
+				cur[c][x] = d.decodeRegular(qs[c], sgn[c], px)
+			}
+			x++
+		}
+		base := y * W * nc
+		for x := 0; x < W; x++ {
+			for c := 0; c < nc; c++ {
+				putSample(out, base+x*nc+c, cur[c][x], bps)
+			}
+		}
+		for c := 0; c < nc; c++ {
+			rcLeft[c] = lineRb0[c]
+			prev[c], cur[c] = cur[c], prev[c]
+		}
+	}
+}
+
+// decodeSampleRun handles run mode for a sample-interleaved scan starting at
+// pixel x. A run reconstructs whole pixels equal to the run pixel ra; the
+// interrupting pixel uses run context 0 for every component with sign(rb-ra)
+// (CharLS decode_run_pixels + decode_run_interruption_pixel for triplet/quad).
+func (d *jlsDecoder) decodeSampleRun(cur, prev [][]int, ra []int, y, x, nc int) int {
+	W := d.f.width
+	remaining := W - x
+	index := 0
+	for d.br.readBit() == 1 {
+		block := 1 << jlsRunJ[d.runIndex]
+		count := block
+		if count > remaining-index {
+			count = remaining - index
+		}
+		index += count
+		if count == block && d.runIndex < 31 {
+			d.runIndex++
+		}
+		if index == remaining {
+			break
+		}
+	}
+	interrupted := index != remaining
+	if interrupted && jlsRunJ[d.runIndex] > 0 {
+		index += d.br.readBits(jlsRunJ[d.runIndex])
+	}
+	if index > remaining {
+		index = remaining
+		interrupted = false
+	}
+	for i := 0; i < index; i++ {
+		for c := 0; c < nc; c++ {
+			cur[c][x+i] = ra[c]
+		}
+	}
+	x += index
+	if interrupted && x < W {
+		for c := 0; c < nc; c++ {
+			rbc := 0
+			if y > 0 {
+				rbc = prev[c][x]
+			}
+			errval := d.decodeRIError(365, 0)
+			if rbc < ra[c] {
+				errval = -errval
+			}
+			cur[c][x] = d.computeRecon(rbc, errval)
+		}
+		x++
+		if d.runIndex > 0 {
+			d.runIndex--
+		}
+	}
+	return x
 }
 
 // decodePlane decodes one component plane (ILV=0) into plane (row-major).
@@ -185,65 +455,8 @@ func (d *jlsDecoder) decodePlane(plane []int) {
 	rcLeft := 0 // R[y-1][-1] for the current line
 
 	for y := 0; y < H; y++ {
-		lineRb0 := 0
-		if y > 0 {
-			lineRb0 = prev[0]
-		}
-		x := 0
-		for x < W {
-			// neighbors
-			var a, b, c, dd int
-			if y == 0 {
-				b, c, dd = 0, 0, 0
-			} else {
-				b = prev[x]
-				if x+1 < W {
-					dd = prev[x+1]
-				} else {
-					dd = b
-				}
-			}
-			if x == 0 {
-				a = lineRb0 // Ra at line start = sample above (b)
-				c = rcLeft
-			} else {
-				a = cur[x-1]
-				if y > 0 {
-					c = prev[x-1]
-				}
-			}
-
-			q1 := d.quantize(dd - b)
-			q2 := d.quantize(b - c)
-			q3 := d.quantize(c - a)
-
-			if q1 == 0 && q2 == 0 && q3 == 0 {
-				x = d.decodeRun(cur, prev, y, a, x, W)
-				continue
-			}
-
-			q := 81*q1 + 9*q2 + q3
-			sign := 1
-			if q < 0 {
-				q = -q
-				sign = -1
-			}
-			px := predict(a, b, c)
-			if sign > 0 {
-				px += d.c[q]
-			} else {
-				px -= d.c[q]
-			}
-			if px < 0 {
-				px = 0
-			} else if px > d.f.maxval {
-				px = d.f.maxval
-			}
-			cur[x] = d.decodeRegular(q, sign, px)
-			x++
-		}
+		rcLeft = d.decodeScalarLine(cur, prev, y, rcLeft)
 		copy(plane[y*W:y*W+W], cur)
-		rcLeft = lineRb0
 		prev, cur = cur, prev
 	}
 }
@@ -368,8 +581,9 @@ func (gojpeglsBackend) DecodeContext(_ context.Context, encoded []byte, output [
 
 func (gojpeglsBackend) Encode(raw []byte, width uint16, height uint16, samples uint16, bitsa uint16, nearLossless bool) ([]byte, error) {
 	// NEAR=1 matches the charls backend's near-lossless setting; NEAR=0 is
-	// lossless. encodeJLS errors for unsupported geometry (e.g. multi-component),
-	// which is correct — better than producing an invalid stream that reports success.
+	// lossless. Multi-component input is encoded line-interleaved (ILV=1).
+	// encodeJLS errors for unsupported geometry rather than producing an invalid
+	// stream that reports success.
 	near := 0
 	if nearLossless {
 		near = 1

--- a/codecs/jpegls/gojpegls_scan.go
+++ b/codecs/jpegls/gojpegls_scan.go
@@ -72,7 +72,7 @@ func parseJLSFrame(seg []byte, f *jlsFrame) error {
 	if nf < 1 || nf > 255 {
 		return errJLSUnsupported
 	}
-	if f.width*f.height*nf > maxJLSSamples {
+	if int64(f.width)*int64(f.height)*int64(nf) > maxJLSSamples {
 		return errJLSUnsupported
 	}
 	if len(seg) < 6+nf*3 {
@@ -156,8 +156,9 @@ func decodeJLSInto(encoded, output []byte) error {
 	if f.precision > 8 {
 		bps = 2
 	}
-	need := f.width * f.height * nc * bps
-	if need > len(output) {
+	// int64 to avoid overflow on 32-bit builds (nc up to 255).
+	need := int64(f.width) * int64(f.height) * int64(nc) * int64(bps)
+	if need > int64(len(output)) {
 		return errJLSOutputSize
 	}
 

--- a/codecs/jpegls/gojpegls_test.go
+++ b/codecs/jpegls/gojpegls_test.go
@@ -146,11 +146,77 @@ func TestGoJLSEncodeRoundTrip(t *testing.T) {
 	}
 }
 
-// TestGoJLSEncodeRejectsUnsupported confirms multi-component encode is reported
+// TestGoJLSEncodeRejectsUnsupported confirms invalid geometry is reported
 // unsupported rather than producing invalid output.
 func TestGoJLSEncodeRejectsUnsupported(t *testing.T) {
-	if _, err := encodeJLS(make([]byte, 3*4*4), 4, 4, 3, 8, 0); err == nil {
-		t.Fatal("expected 3-component encode to be unsupported")
+	if _, err := encodeJLS(make([]byte, 4*4), 4, 4, 0, 8, 0); err == nil {
+		t.Fatal("expected 0-component encode to be unsupported")
+	}
+	if _, err := encodeJLS(make([]byte, 3*4*4-1), 4, 4, 3, 8, 0); err == nil {
+		t.Fatal("expected mismatched raw length to be unsupported")
+	}
+}
+
+// TestGoJLSMultiComponentEncodeRoundTrip encodes synthetic multi-component images
+// with the pure-Go encoder (line-interleaved) and decodes them back with the
+// pure-Go decoder, requiring an exact (lossless) match for NEAR=0 and within-NEAR
+// fidelity for NEAR>0.
+func TestGoJLSMultiComponentEncodeRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		w, h, comps, p, near int
+	}{
+		{16, 16, 3, 8, 0}, {20, 12, 3, 8, 1}, {17, 9, 3, 12, 0},
+		{32, 8, 3, 16, 2}, {10, 10, 4, 8, 0}, {13, 11, 4, 12, 1},
+	} {
+		bps := 1
+		if tc.p > 8 {
+			bps = 2
+		}
+		maxv := (1 << tc.p) - 1
+		n := tc.w * tc.h * tc.comps
+		raw := make([]byte, n*bps)
+		get := func(i int) int {
+			if bps == 1 {
+				return int(raw[i])
+			}
+			return int(raw[i*2]) | int(raw[i*2+1])<<8
+		}
+		for i := 0; i < n; i++ {
+			v := (i*7 + (i*i)%29 + (i%tc.comps)*11) % (maxv + 1)
+			if bps == 1 {
+				raw[i] = byte(v)
+			} else {
+				raw[i*2] = byte(v)
+				raw[i*2+1] = byte(v >> 8)
+			}
+		}
+		enc, err := encodeJLS(raw, tc.w, tc.h, tc.comps, tc.p, tc.near)
+		if err != nil {
+			t.Fatalf("%dc p%d near%d encode: %v", tc.comps, tc.p, tc.near, err)
+		}
+		f, _, err := parseJLS(enc)
+		if err != nil {
+			t.Fatalf("%dc parse own stream: %v", tc.comps, err)
+		}
+		if f.ilv != 1 || len(f.comps) != tc.comps {
+			t.Fatalf("%dc expected ILV=1 with %d comps, got ilv=%d comps=%d", tc.comps, tc.comps, f.ilv, len(f.comps))
+		}
+		out := make([]byte, len(raw))
+		if err := decodeJLSInto(enc, out); err != nil {
+			t.Fatalf("%dc decode: %v", tc.comps, err)
+		}
+		for i := 0; i < n; i++ {
+			o := get(i)
+			var g int
+			if bps == 1 {
+				g = int(out[i])
+			} else {
+				g = int(out[i*2]) | int(out[i*2+1])<<8
+			}
+			if d := o - g; d < -tc.near || d > tc.near {
+				t.Fatalf("%dc p%d near%d sample %d: got %d want within %d of %d", tc.comps, tc.p, tc.near, i, g, tc.near, o)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds interleaved JPEG-LS support — the last pure-Go feature gap versus the charls backend. Pure-Go JPEG-LS now covers lossless + near-lossless, single + multi-component, and all interleave modes on decode (plus planar + line-interleaved on encode).

## Decode — all three interleave modes
| Mode | Validation | Result |
|---|---|---|
| ILV=2 sample-interleaved (3/4-comp) | real highdicom RGB fixtures vs charls | byte-exact |
| ILV=1 line-interleaved | charls streams: 3/4-comp × 8/12/16-bit × NEAR 0/1/2 | byte-exact |
| ILV=0 non-interleaved | tightened to single-component | — |

The subtle semantics the byte-exact match confirms:
- Interleaved modes **share** the regular/run context statistics across components; `run_index` is per-component only in line mode.
- Sample-interleaved enters run mode only when **every** component's context is 0; runs reconstruct whole pixels; run interruption uses run context 0 for every component with `sign(rb−ra)` (no per-component NEAR test).
- Both interleaved modes emit pixel-interleaved (RGBRGB) output, matching charls.
- ILV=0 is restricted to single-component (standard multi-component non-interleaved uses *separate scans*, which this single-scan reader does not assemble); ILV=2 is restricted to 3/4 components.

## Encode
Multi-component input is encoded **line-interleaved (ILV=1)**, matching the charls backend. charls decodes the pure-Go output to identical pixels as the pure-Go decoder, within NEAR.

## Refactor
Scalar per-line decode/encode logic is factored into `decodeScalarLine` / `encodeScalarLine`, shared by the planar and line-interleaved paths (the existing lossless/near-lossless golden tests still pass byte-exact, confirming no regression).

## Verification
Full no-cgo `./...`, cgo jpegls + media, gofmt, vet — all green. Decoder remains fuzz-clean over the broadened parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)