### PR TITLE
chore(release): bump version to 3.5.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the current release version of the io-dicom library.
-const Version = "3.1.0"
+const Version = "3.5.0"


### PR DESCRIPTION
Bumps `internal/version.Version` to **3.5.0** ahead of cutting the v3.5.0 release.

This release captures the pure-Go codec arc (#14–#17):
- Pure-Go **JPEG** decode + encode — baseline (`.50`), extended 12-bit DCT (`.51`), lossless (`.57`/`.70`).
- Pure-Go **JPEG-LS** decode + encode — lossless (`.80`) and near-lossless (`.81`), single- and multi-component (non-interleaved, line-interleaved, sample-interleaved).
- Retirement of the **charls** and **libjpeg** cgo backends, with byte-exact validation frozen as committed golden vectors that run in the no-cgo CI job.

No functional change in this PR beyond the version constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)