### PR TITLE
fix(jpeg2000): harden pure-Go encoder input validation

### DIFF
--- a/codecs/jpeg2000/gojp2k_encode.go
+++ b/codecs/jpeg2000/gojp2k_encode.go
@@ -155,17 +155,34 @@ func bitLen(v int) int {
 
 const encGuardBits = 2
 
+// maxJ2KComponents caps the component count the pure-Go encoder accepts. DICOM
+// pixel data uses 1 (monochrome) or 3 (colour); this is a generous upper bound
+// that rejects absurd values while never constraining real images.
+const maxJ2KComponents = 256
+
 // goJ2Kencode encodes raw little-endian samples (1 byte/sample for prec≤8, else
 // 2) into a lossless 5/3 JPEG 2000 codestream.
 func goJ2Kencode(raw []byte, w, h, nc, prec int) ([]byte, error) {
-	if w <= 0 || h <= 0 || nc <= 0 || prec <= 0 || prec > 16 {
+	if w <= 0 || h <= 0 || nc <= 0 || prec <= 0 || prec > 16 || nc > maxJ2KComponents {
 		return nil, errJ2KUnsupported
 	}
 	bps := 1
 	if prec > 8 {
 		bps = 2
 	}
-	if len(raw) < w*h*nc*bps {
+	// Require the raw payload to be exactly w·h·nc·bps bytes (no missing or extra
+	// bytes), computed overflow-safe: accumulate in int64 and reject as soon as the
+	// running product exceeds the codec's payload cap, so a hostile w/h/nc cannot
+	// overflow int. Each factor multiplies a value already capped, so no
+	// intermediate can overflow int64.
+	need := int64(w)
+	for _, f := range []int{h, nc, bps} {
+		if need > maxCodecPayloadBytes {
+			return nil, errInvalidJ2KPayload
+		}
+		need *= int64(f)
+	}
+	if need > maxCodecPayloadBytes || int64(len(raw)) != need {
 		return nil, errInvalidJ2KPayload
 	}
 

--- a/codecs/jpeg2000/gojp2k_encode.go
+++ b/codecs/jpeg2000/gojp2k_encode.go
@@ -171,18 +171,18 @@ func goJ2Kencode(raw []byte, w, h, nc, prec int) ([]byte, error) {
 		bps = 2
 	}
 	// Require the raw payload to be exactly w·h·nc·bps bytes (no missing or extra
-	// bytes), computed overflow-safe: accumulate in int64 and reject as soon as the
-	// running product exceeds the codec's payload cap, so a hostile w/h/nc cannot
-	// overflow int. Each factor multiplies a value already capped, so no
-	// intermediate can overflow int64.
+	// bytes). Compute the size overflow-safe: before each multiply, a
+	// division-based guard ensures the running product never exceeds the codec's
+	// payload cap, so a hostile w/h/nc (any factor) can never overflow int64.
 	need := int64(w)
 	for _, f := range []int{h, nc, bps} {
-		if need > maxCodecPayloadBytes {
+		ff := int64(f)
+		if ff <= 0 || need > maxCodecPayloadBytes/ff {
 			return nil, errInvalidJ2KPayload
 		}
-		need *= int64(f)
+		need *= ff
 	}
-	if need > maxCodecPayloadBytes || int64(len(raw)) != need {
+	if int64(len(raw)) != need {
 		return nil, errInvalidJ2KPayload
 	}
 

--- a/codecs/jpeg2000/gojp2k_encode_test.go
+++ b/codecs/jpeg2000/gojp2k_encode_test.go
@@ -47,3 +47,32 @@ func TestEncodeRoundTripSelf(t *testing.T) {
 		t.Logf("%+v: round-trip OK (%d raw → %d coded)", c, len(raw), len(stream))
 	}
 }
+
+// TestEncodeInputValidation checks that goJ2Kencode rejects malformed parameters
+// and non-exact payload sizes instead of silently accepting them.
+func TestEncodeInputValidation(t *testing.T) {
+	good := make([]byte, 4*4*1*1) // 4×4, 1 comp, 8-bit
+	cases := []struct {
+		name           string
+		raw            []byte
+		w, h, nc, prec int
+	}{
+		{"ok-exact", good, 4, 4, 1, 8},
+		{"too-few-bytes", good[:len(good)-1], 4, 4, 1, 8},
+		{"too-many-bytes", append(append([]byte{}, good...), 0), 4, 4, 1, 8},
+		{"zero-width", good, 0, 4, 1, 8},
+		{"zero-prec", good, 4, 4, 1, 0},
+		{"prec-too-large", good, 4, 4, 1, 17},
+		{"too-many-components", good, 4, 4, maxJ2KComponents + 1, 8},
+	}
+	for _, c := range cases {
+		_, err := goJ2Kencode(c.raw, c.w, c.h, c.nc, c.prec)
+		if c.name == "ok-exact" {
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", c.name, err)
+			}
+		} else if err == nil {
+			t.Errorf("%s: expected error, got nil", c.name)
+		}
+	}
+}

--- a/codecs/jpeg2000/gojp2k_encode_test.go
+++ b/codecs/jpeg2000/gojp2k_encode_test.go
@@ -64,6 +64,8 @@ func TestEncodeInputValidation(t *testing.T) {
 		{"zero-prec", good, 4, 4, 1, 0},
 		{"prec-too-large", good, 4, 4, 1, 17},
 		{"too-many-components", good, 4, 4, maxJ2KComponents + 1, 8},
+		{"huge-height-overflow", good, 4, 1 << 40, 1, 8},
+		{"huge-width-overflow", good, 1 << 40, 4, 1, 8},
 	}
 	for _, c := range cases {
 		_, err := goJ2Kencode(c.raw, c.w, c.h, c.nc, c.prec)


### PR DESCRIPTION
## Summary

Addresses a post-merge Copilot review on the pure-Go encoder (#21).
`goJ2Kencode` accepted any component count and only checked
`len(raw) < w*h*nc*bps`, which:

- silently accepted **extra trailing bytes** (malformed input), and
- did the size math in `int`, which could **overflow** on hostile `w`/`h`/`nc`.

## Changes

- Require the raw payload to be **exactly** `w·h·nc·bps` bytes. The real caller
  (`transcoder.frameBounds`) already slices an exact-size frame, so this rejects
  malformed input without affecting legitimate use.
- Compute the size **overflow-safe** in `int64` with a running cap against
  `maxCodecPayloadBytes` (mirrors `goJ2Kdecode`).
- Cap the component count (`maxJ2KComponents = 256`; DICOM pixel data uses 1 or
  3).

Adds `TestEncodeInputValidation` covering exact/short/long payloads and the
parameter bounds. Full suite green; `go vet` / `staticcheck` clean.

Independent of the openjpeg-removal PR (#22) — touches only `gojp2k_encode.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)