### PR TITLE
chore(jpeg2000): inline CGOEnabled, drop vestigial native-backend file

### DIFF
--- a/codecs/jpeg2000/codec.go
+++ b/codecs/jpeg2000/codec.go
@@ -9,9 +9,10 @@ import (
 )
 
 // CGOEnabled reports whether a native (cgo) JPEG 2000 backend is compiled in.
-// There is none anymore — decode and lossless encode are pure Go — so it is
-// always false. Retained for API compatibility with callers/tests.
-var CGOEnabled = nativeBackendEnabled
+// The openjpeg backend was retired in favor of the pure-Go gojpeg2000 codec
+// (decode + lossless encode), so this is always false; it is retained for API
+// compatibility with callers/tests (matching codecs/jpeg and codecs/jpegls).
+const CGOEnabled = false
 
 const maxCodecPayloadBytes = 512 << 20
 
@@ -65,8 +66,7 @@ func (passthroughBackend) Encode(_ []byte, _ uint16, _ uint16, _ uint16, _ uint1
 var mgr = backendmgr.New(func() Backend { return passthroughBackend{} })
 
 func init() {
-	registerNativeBackends() // no-op (no native backend); kept for symmetry
-	registerPureGoBackend()  // pure-Go gojpeg2000 (decode + lossless 5/3 encode)
+	registerPureGoBackend() // pure-Go gojpeg2000 (decode + lossless 5/3 encode)
 	mgr.SelectDefault()
 	if mgr.BackendName() == "passthrough" {
 		slog.Warn("jpeg2000: no decode backend available")

--- a/codecs/jpeg2000/native_backends.go
+++ b/codecs/jpeg2000/native_backends.go
@@ -1,9 +1,0 @@
-package jpeg2000
-
-// No native (cgo) JPEG 2000 backend: the decoder and lossless encoder are pure
-// Go. registerNativeBackends is a no-op kept so codec.go's init can call it
-// uniformly; nativeBackendEnabled stays false.
-
-const nativeBackendEnabled = false
-
-func registerNativeBackends() {}


### PR DESCRIPTION
## Summary

After the openjpeg backend was removed (#22), `codecs/jpeg2000/native_backends.go`
was left behind as a no-op: it held `nativeBackendEnabled = false` and an empty
`registerNativeBackends()` that `init()` called for no reason.

`codecs/jpeg` and `codecs/jpegls` already settled on the clean form when their cgo
backends (libjpeg / charls) were retired — a plain `const CGOEnabled = false` in
`codec.go` and **no** scaffolding file. This aligns jpeg2000 with them.

## Changes
- Inline `const CGOEnabled = false` in `codec.go` (was `var CGOEnabled =
  nativeBackendEnabled`).
- Drop the `registerNativeBackends()` call from `init()`.
- Delete `native_backends.go`.

No behavior change — `CGOEnabled` was already always false, and
`registerNativeBackends` was a no-op. `codecs/jpeg2000` now has no
`native_backends*` files, matching `codecs/jpeg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)