### PR TITLE
perf(jpegls): fix decode OOM and speed up decode ~1.75x

### DIFF
--- a/codecs/jpegls/bench_test.go
+++ b/codecs/jpegls/bench_test.go
@@ -1,0 +1,93 @@
+package jpegls
+
+import (
+	"encoding/binary"
+	"os"
+	"testing"
+)
+
+// synthFrame builds a 16-bit grayscale frame with smooth gradients plus noise,
+// a workload representative of medical pixel data (mix of run and regular mode).
+func synthFrame(w, h int) []byte {
+	out := make([]byte, w*h*2)
+	seed := uint32(12345)
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			seed = seed*1664525 + 1013904223
+			v := uint16((x*7+y*13)&0x0FFF) ^ uint16(seed>>20&0x3F)
+			i := (y*w + x) * 2
+			binary.LittleEndian.PutUint16(out[i:], v)
+		}
+	}
+	return out
+}
+
+func benchDecode(b *testing.B, stream []byte, outLen int) {
+	out := make([]byte, outLen)
+	b.SetBytes(int64(outLen))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := decodeJLSInto(stream, out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func benchSynth(b *testing.B, w, h int) {
+	raw := synthFrame(w, h)
+	stream, err := encodeJLS(raw, w, h, 1, 16, 0)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchDecode(b, stream, len(raw))
+}
+
+func BenchmarkDecodeSynth512(b *testing.B)  { benchSynth(b, 512, 512) }
+func BenchmarkDecodeSynth2048(b *testing.B) { benchSynth(b, 2048, 2048) }
+
+// BenchmarkDecodeFixture decodes a real lossless JPEG-LS CT frame (512x512, 16-bit).
+func BenchmarkDecodeFixture(b *testing.B) {
+	dcm, err := os.ReadFile("../../testdata/cornerstone-CTImage-jpegls-lossless.dcm")
+	if err != nil {
+		b.Skip(err)
+	}
+	frame := firstEncapsulatedFrame(b, dcm)
+	if frame == nil {
+		b.Skip("no frame")
+	}
+	benchDecode(b, frame, 512*512*2)
+}
+
+// firstEncapsulatedFrame extracts the first pixel-data fragment from an
+// encapsulated DICOM object (skipping the basic offset table item).
+func firstEncapsulatedFrame(b *testing.B, dcm []byte) []byte {
+	b.Helper()
+	pix := []byte{0xE0, 0x7F, 0x10, 0x00}
+	idx := -1
+	for i := 0; i < len(dcm)-12; i++ {
+		if dcm[i] == pix[0] && dcm[i+1] == pix[1] && dcm[i+2] == pix[2] && dcm[i+3] == pix[3] {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return nil
+	}
+	pos := idx + 12
+	read := func() []byte {
+		if pos+8 > len(dcm) {
+			return nil
+		}
+		l := binary.LittleEndian.Uint32(dcm[pos+4 : pos+8])
+		pos += 8
+		if l == 0xFFFFFFFF || pos+int(l) > len(dcm) {
+			return nil
+		}
+		f := dcm[pos : pos+int(l)]
+		pos += int(l)
+		return f
+	}
+	read() // basic offset table
+	return read()
+}

--- a/codecs/jpegls/gojpegls.go
+++ b/codecs/jpegls/gojpegls.go
@@ -13,6 +13,7 @@ package jpegls
 
 import (
 	"errors"
+	"math/bits"
 )
 
 var (
@@ -56,39 +57,105 @@ type jlsFrame struct {
 // emits a 0xFF data byte it inserts a 0 bit immediately after, so on decode the
 // bit following a 0xFF byte is a stuffed bit to skip (the next byte yields only
 // 7 payload bits, bits 6..0). Past end-of-data, zero bits are returned.
+//
+// Bits are refilled into a 64-bit accumulator a byte at a time, with the stuffed
+// bit removed at fill time, so the accumulator is a clean stuffing-free bit
+// stream. This lets readBits extract n bits with a single shift and lets the
+// unary decoder count zero runs with a hardware leading-zeros instruction rather
+// than one method call per bit.
 type jlsBitReader struct {
 	data      []byte
 	pos       int
-	cur       byte
-	bitpos    int  // remaining unread bits in cur (0 = need next byte)
-	lastWasFF bool // the previously loaded byte was 0xFF
+	acc       uint64 // valid bits live in the low nbits; next bit is bit (nbits-1)
+	nbits     int    // number of valid bits currently in acc (0..63)
+	lastWasFF bool   // the previously loaded byte was 0xFF
 }
 
-func (br *jlsBitReader) readBit() int {
-	if br.bitpos == 0 {
-		if br.pos >= len(br.data) {
-			return 0 // pad with zeros past EOF
-		}
+// fill loads bytes into acc until it holds at least 56 bits or the data is
+// exhausted. Stuffed bits (the MSB following a 0xFF byte) are dropped here.
+func (br *jlsBitReader) fill() {
+	for br.nbits <= 56 && br.pos < len(br.data) {
 		b := br.data[br.pos]
 		br.pos++
-		br.cur = b
 		if br.lastWasFF {
-			br.bitpos = 7 // skip the stuffed MSB
+			br.acc = br.acc<<7 | uint64(b&0x7F)
+			br.nbits += 7
 		} else {
-			br.bitpos = 8
+			br.acc = br.acc<<8 | uint64(b)
+			br.nbits += 8
 		}
 		br.lastWasFF = b == 0xFF
 	}
-	br.bitpos--
-	return int((br.cur >> br.bitpos) & 1)
+}
+
+func (br *jlsBitReader) readBit() int {
+	if br.nbits == 0 {
+		br.fill()
+		if br.nbits == 0 {
+			return 0 // pad with zeros past EOF
+		}
+	}
+	br.nbits--
+	return int((br.acc >> br.nbits) & 1)
 }
 
 func (br *jlsBitReader) readBits(n int) int {
-	v := 0
-	for i := 0; i < n; i++ {
-		v = v<<1 | br.readBit()
+	if n == 0 {
+		return 0
 	}
-	return v
+	for br.nbits < n {
+		before := br.nbits
+		br.fill()
+		if br.nbits == before {
+			// EOF: take what remains, pad the rest with zero bits (MSB-first).
+			v := int(br.acc&mask(br.nbits)) << (n - br.nbits)
+			br.nbits = 0
+			return v
+		}
+	}
+	br.nbits -= n
+	return int((br.acc >> br.nbits) & mask(n))
+}
+
+// readZeros counts and consumes a run of zero bits terminated by a 1 bit (which
+// is also consumed), capping the count at cap to bound malformed input. It is
+// the unary-prefix fast path for decodeValue and is exactly equivalent to
+// calling readBit until it returns 1.
+func (br *jlsBitReader) readZeros(cap int) int {
+	count := 0
+	for {
+		if br.nbits == 0 {
+			br.fill()
+			if br.nbits == 0 {
+				return cap // past EOF: treat as an over-long (capped) run
+			}
+		}
+		// Left-align the nbits valid bits so the first unread bit is bit 63.
+		w := br.acc << (64 - br.nbits)
+		lz := bits.LeadingZeros64(w)
+		if lz >= br.nbits {
+			count += br.nbits
+			br.nbits = 0
+			if count >= cap {
+				return cap
+			}
+			continue
+		}
+		count += lz
+		br.nbits -= lz + 1 // consume the zeros and the terminating 1
+		if count >= cap {
+			return cap
+		}
+		return count
+	}
+}
+
+// mask returns a bit mask with the low n bits set (n in 0..64).
+func mask(n int) uint64 {
+	if n >= 64 {
+		return ^uint64(0)
+	}
+	return 1<<uint(n) - 1
 }
 
 // ceilLog2 returns ceil(log2(n)) for n >= 1.
@@ -152,9 +219,19 @@ type jlsDecoder struct {
 	bpp    int
 	limit  int
 
-	a, b, n, c []int // context arrays, length 367
-	nn         []int // negative-count for run-interruption contexts 365/366
-	runIndex   int
+	ctx      []ctxState // per-context model state, length 367
+	runIndex int
+
+	qLUT []int8 // quantize lookup: qLUT[diff+qOff] for diff in [-maxval, maxval]
+	qOff int    // = maxval; bias to index qLUT by a signed diff
+}
+
+// ctxState is the per-context model state. Grouping a/b/c/n (and nn for the two
+// run-interruption contexts) into one struct keeps a context's fields on a
+// single cache line, since every regular-mode sample reads and writes all of
+// them together.
+type ctxState struct {
+	a, b, c, n, nn int
 }
 
 func newJLSDecoder(f *jlsFrame, entropy []byte) *jlsDecoder {
@@ -164,20 +241,29 @@ func newJLSDecoder(f *jlsFrame, entropy []byte) *jlsDecoder {
 	d.bpp = max(2, ceilLog2(f.maxval+1))
 	d.limit = 2 * (d.bpp + max(8, d.bpp))
 	aInit := max(2, (d.range_+32)/64)
-	d.a = make([]int, 367)
-	d.b = make([]int, 367)
-	d.n = make([]int, 367)
-	d.c = make([]int, 367)
-	d.nn = make([]int, 367)
-	for i := range d.a {
-		d.a[i] = aInit
-		d.n[i] = 1
+	d.ctx = make([]ctxState, 367)
+	for i := range d.ctx {
+		d.ctx[i].a = aInit
+		d.ctx[i].n = 1
 	}
+	d.buildQuantizeLUT()
 	return d
 }
 
-func (d *jlsDecoder) quantize(diff int) int {
-	near, t1, t2, t3 := d.f.near, d.f.t1, d.f.t2, d.f.t3
+// buildQuantizeLUT precomputes the gradient-quantization region for every
+// possible neighbor difference (diff in [-maxval, maxval]), so the per-sample
+// quantize() is a single array lookup instead of a threshold-ladder branch.
+func (d *jlsDecoder) buildQuantizeLUT() {
+	d.qOff = d.f.maxval
+	d.qLUT = make([]int8, 2*d.f.maxval+1)
+	for diff := -d.f.maxval; diff <= d.f.maxval; diff++ {
+		d.qLUT[diff+d.qOff] = int8(quantizeDiff(diff, d.f.near, d.f.t1, d.f.t2, d.f.t3))
+	}
+}
+
+// quantizeDiff is the scalar gradient quantizer (T.87 A.3.3); buildQuantizeLUT
+// tabulates it.
+func quantizeDiff(diff, near, t1, t2, t3 int) int {
 	switch {
 	case diff <= -t3:
 		return -4
@@ -200,15 +286,16 @@ func (d *jlsDecoder) quantize(diff int) int {
 	}
 }
 
+func (d *jlsDecoder) quantize(diff int) int {
+	return int(d.qLUT[diff+d.qOff])
+}
+
 // decodeValue decodes a limited-length Golomb code with parameter k and the
 // given limit (CharLS DecodeValue / T.87 A.5.3).
 func (d *jlsDecoder) decodeValue(k, limit int) int {
-	high := 0
-	for d.br.readBit() == 0 {
-		high++
-		if high > limit+d.qbpp+64 {
-			return 0 // guard against runaway on malformed input
-		}
+	high := d.br.readZeros(limit + d.qbpp + 64)
+	if high >= limit+d.qbpp+64 {
+		return 0 // guard against runaway on malformed input
 	}
 	if high >= limit-(d.qbpp+1) {
 		return d.br.readBits(d.qbpp) + 1
@@ -249,8 +336,9 @@ func (d *jlsDecoder) computeRecon(px, errval int) int {
 // decodeRegular decodes one regular-mode sample given the context Q, the context
 // sign, and the sign-corrected prediction px.
 func (d *jlsDecoder) decodeRegular(q, sign, px int) int {
+	cs := &d.ctx[q]
 	k := 0
-	for (d.n[q] << k) < d.a[q] {
+	for (cs.n << k) < cs.a {
 		k++
 	}
 	errval := unmapErrval(d.decodeValue(k, d.limit))
@@ -258,45 +346,45 @@ func (d *jlsDecoder) decodeRegular(q, sign, px int) int {
 	// CharLS calls get_error_correction(near_lossless), which returns 0 whenever
 	// its argument is nonzero — so the flip applies in pure-lossless mode only
 	// (NEAR==0). In near-lossless mode the correction is never applied.
-	if k == 0 && d.f.near == 0 && 2*d.b[q]+d.n[q]-1 < 0 {
+	if k == 0 && d.f.near == 0 && 2*cs.b+cs.n-1 < 0 {
 		errval = -errval - 1
 	}
 	rx := d.computeRecon(px, sign*errval)
-	d.updateRegular(q, errval)
+	updateRegular(cs, errval, d.f.near, d.f.reset)
 	return rx
 }
 
 // updateRegular updates the regular context A/B/N and the bias correction C.
-func (d *jlsDecoder) updateRegular(q, errval int) {
-	d.a[q] += abs(errval)
-	d.b[q] += errval * (2*d.f.near + 1)
-	if d.n[q] == d.f.reset {
-		d.a[q] >>= 1
-		if d.b[q] >= 0 {
-			d.b[q] >>= 1
+func updateRegular(cs *ctxState, errval, near, reset int) {
+	cs.a += abs(errval)
+	cs.b += errval * (2*near + 1)
+	if cs.n == reset {
+		cs.a >>= 1
+		if cs.b >= 0 {
+			cs.b >>= 1
 		} else {
-			d.b[q] = -((1 - d.b[q]) >> 1)
+			cs.b = -((1 - cs.b) >> 1)
 		}
-		d.n[q] >>= 1
+		cs.n >>= 1
 	}
-	d.n[q]++
-	if d.b[q] <= -d.n[q] {
-		d.c[q]--
-		if d.c[q] < -128 {
-			d.c[q] = -128
+	cs.n++
+	if cs.b <= -cs.n {
+		cs.c--
+		if cs.c < -128 {
+			cs.c = -128
 		}
-		d.b[q] += d.n[q]
-		if d.b[q] <= -d.n[q] {
-			d.b[q] = -d.n[q] + 1
+		cs.b += cs.n
+		if cs.b <= -cs.n {
+			cs.b = -cs.n + 1
 		}
-	} else if d.b[q] > 0 {
-		d.c[q]++
-		if d.c[q] > 127 {
-			d.c[q] = 127
+	} else if cs.b > 0 {
+		cs.c++
+		if cs.c > 127 {
+			cs.c = 127
 		}
-		d.b[q] -= d.n[q]
-		if d.b[q] > 0 {
-			d.b[q] = 0
+		cs.b -= cs.n
+		if cs.b > 0 {
+			cs.b = 0
 		}
 	}
 }

--- a/codecs/jpegls/gojpegls.go
+++ b/codecs/jpegls/gojpegls.go
@@ -293,8 +293,13 @@ func (d *jlsDecoder) quantize(diff int) int {
 // decodeValue decodes a limited-length Golomb code with parameter k and the
 // given limit (CharLS DecodeValue / T.87 A.5.3).
 func (d *jlsDecoder) decodeValue(k, limit int) int {
-	high := d.br.readZeros(limit + d.qbpp + 64)
-	if high >= limit+d.qbpp+64 {
+	// runCap bounds the unary zero-run for malformed input; it is far beyond any
+	// valid prefix length. Read runCap+1 so a legitimate run of exactly runCap
+	// zeros (terminated by a 1) stays decodable, while only a strictly longer
+	// run — or EOF — trips the runaway guard.
+	runCap := limit + d.qbpp + 64
+	high := d.br.readZeros(runCap + 1)
+	if high > runCap {
 		return 0 // guard against runaway on malformed input
 	}
 	if high >= limit-(d.qbpp+1) {

--- a/codecs/jpegls/gojpegls.go
+++ b/codecs/jpegls/gojpegls.go
@@ -67,7 +67,7 @@ type jlsBitReader struct {
 	data      []byte
 	pos       int
 	acc       uint64 // valid bits live in the low nbits; next bit is bit (nbits-1)
-	nbits     int    // number of valid bits currently in acc (0..63)
+	nbits     int    // number of valid bits currently in acc (0..64)
 	lastWasFF bool   // the previously loaded byte was 0xFF
 }
 

--- a/codecs/jpegls/gojpegls_encode.go
+++ b/codecs/jpegls/gojpegls_encode.go
@@ -67,8 +67,9 @@ func (d *jlsDecoder) encodeValue(w *jlsBitWriter, merr, k, limit int) {
 
 // encodeRegular encodes one regular-mode sample (inverse of decodeRegular).
 func (d *jlsDecoder) encodeRegular(w *jlsBitWriter, q, sign, px, sample int) int {
+	cs := &d.ctx[q]
 	k := 0
-	for (d.n[q] << k) < d.a[q] {
+	for (cs.n << k) < cs.a {
 		k++
 	}
 	// errval such that the decoder reconstructs an in-tolerance sample from px.
@@ -84,7 +85,7 @@ func (d *jlsDecoder) encodeRegular(w *jlsBitWriter, q, sign, px, sample int) int
 	// inverse of the k==0 bias flip; applies in pure-lossless mode only (NEAR==0),
 	// matching the decoder / CharLS get_error_correction(near_lossless).
 	mapped := errval
-	if k == 0 && d.f.near == 0 && 2*d.b[q]+d.n[q]-1 < 0 {
+	if k == 0 && d.f.near == 0 && 2*cs.b+cs.n-1 < 0 {
 		mapped = -errval - 1
 	}
 	var merr int
@@ -94,7 +95,7 @@ func (d *jlsDecoder) encodeRegular(w *jlsBitWriter, q, sign, px, sample int) int
 		merr = -2*mapped - 1
 	}
 	d.encodeValue(w, merr, k, d.limit)
-	d.updateRegular(q, errval)
+	updateRegular(cs, errval, d.f.near, d.f.reset)
 	// Return the value the decoder will reconstruct, so the encoder feeds
 	// reconstructed (not original) neighbors — required for near-lossless.
 	return d.computeRecon(px, sign*errval)
@@ -135,14 +136,15 @@ func (d *jlsDecoder) encodeRunInterruption(w *jlsBitWriter, ra, rb, sample int) 
 		errval -= d.range_
 	}
 
-	temp := d.a[q] + (d.n[q]>>1)*nRItype
+	cs := &d.ctx[q]
+	temp := cs.a + (cs.n>>1)*nRItype
 	k := 0
-	for (d.n[q] << k) < temp {
+	for (cs.n << k) < temp {
 		k++
 	}
 	// inverse of ComputeErrVal: find EMErrval whose decode yields errval.
 	mapFlagBase := 0
-	if k != 0 || 2*d.nn[q] >= d.n[q] {
+	if k != 0 || 2*cs.nn >= cs.n {
 		mapFlagBase = 1
 	}
 	// errval = (condition==map) ? -errAbs : errAbs, with map=(EMErrval+nRItype)&1.
@@ -167,16 +169,16 @@ func (d *jlsDecoder) encodeRunInterruption(w *jlsBitWriter, ra, rb, sample int) 
 
 	// context update (identical to decode)
 	if errval < 0 {
-		d.nn[q]++
+		cs.nn++
 	}
 	emerr := t
-	d.a[q] += (emerr + 1 - nRItype) >> 1
-	if d.n[q] == d.f.reset {
-		d.a[q] >>= 1
-		d.n[q] >>= 1
-		d.nn[q] >>= 1
+	cs.a += (emerr + 1 - nRItype) >> 1
+	if cs.n == d.f.reset {
+		cs.a >>= 1
+		cs.n >>= 1
+		cs.nn >>= 1
 	}
-	d.n[q]++
+	cs.n++
 	// The decoder reconstructs the interrupting sample from px and the signed
 	// error; return it so the encoder feeds reconstructed neighbors.
 	return d.computeRecon(px, sign*errval)
@@ -233,9 +235,9 @@ func (d *jlsDecoder) encodeScalarLine(w *jlsBitWriter, cur, prev []int, y, rcLef
 		}
 		px := predict(a, b, c)
 		if sign > 0 {
-			px += d.c[q]
+			px += d.ctx[q].c
 		} else {
-			px -= d.c[q]
+			px -= d.ctx[q].c
 		}
 		if px < 0 {
 			px = 0

--- a/codecs/jpegls/gojpegls_scan.go
+++ b/codecs/jpegls/gojpegls_scan.go
@@ -170,13 +170,12 @@ func decodeJLSInto(encoded, output []byte) error {
 		d.decodeSampleInterleaved(output, nc, bps)
 	default:
 		// Non-interleaved (ILV=0): each component is a full plane, decoded in
-		// turn, then packed pixel-interleaved (component-minor), little-endian.
+		// turn and written directly into the pixel-interleaved (component-minor),
+		// little-endian output one line at a time. Streaming per line avoids a
+		// W*H intermediate int plane (8 bytes/sample), which on large images was
+		// the dominant allocation and could OOM the process.
 		for c := 0; c < nc; c++ {
-			plane := make([]int, f.width*f.height)
-			d.decodePlane(plane)
-			for i, v := range plane {
-				putSample(output, i*nc+c, v, bps)
-			}
+			d.decodePlaneInto(output, c, nc, bps)
 		}
 	}
 	return nil
@@ -189,32 +188,27 @@ func decodeJLSInto(encoded, output []byte) error {
 // scans save/restore d.runIndex per component around this call.
 func (d *jlsDecoder) decodeScalarLine(cur, prev []int, y, rcLeft int) int {
 	W := d.f.width
-	lineRb0 := 0
-	if y > 0 {
-		lineRb0 = prev[0]
-	}
+	// The callers zero-initialize prev for row 0, so reading prev[x] yields the
+	// correct all-zero neighbors there; the per-pixel y==0 special-cases are thus
+	// redundant and omitted, keeping the hot inner loop branch-free on row index.
+	lineRb0 := prev[0]
 	x := 0
 	for x < W {
 		// neighbors
-		var a, b, c, dd int
-		if y == 0 {
-			b, c, dd = 0, 0, 0
+		b := prev[x]
+		var dd int
+		if x+1 < W {
+			dd = prev[x+1]
 		} else {
-			b = prev[x]
-			if x+1 < W {
-				dd = prev[x+1]
-			} else {
-				dd = b
-			}
+			dd = b
 		}
+		var a, c int
 		if x == 0 {
 			a = lineRb0 // Ra at line start = sample above (b)
 			c = rcLeft
 		} else {
 			a = cur[x-1]
-			if y > 0 {
-				c = prev[x-1]
-			}
+			c = prev[x-1]
 		}
 
 		q1 := d.quantize(dd - b)
@@ -234,9 +228,9 @@ func (d *jlsDecoder) decodeScalarLine(cur, prev []int, y, rcLeft int) int {
 		}
 		px := predict(a, b, c)
 		if sign > 0 {
-			px += d.c[q]
+			px += d.ctx[q].c
 		} else {
-			px -= d.c[q]
+			px -= d.ctx[q].c
 		}
 		if px < 0 {
 			px = 0
@@ -365,9 +359,9 @@ func (d *jlsDecoder) decodeSampleInterleaved(out []byte, nc, bps int) {
 			for c := 0; c < nc; c++ {
 				px := predict(ra[c], rb[c], rc[c])
 				if sgn[c] > 0 {
-					px += d.c[qs[c]]
+					px += d.ctx[qs[c]].c
 				} else {
-					px -= d.c[qs[c]]
+					px -= d.ctx[qs[c]].c
 				}
 				if px < 0 {
 					px = 0
@@ -447,8 +441,11 @@ func (d *jlsDecoder) decodeSampleRun(cur, prev [][]int, ra []int, y, x, nc int) 
 	return x
 }
 
-// decodePlane decodes one component plane (ILV=0) into plane (row-major).
-func (d *jlsDecoder) decodePlane(plane []int) {
+// decodePlaneInto decodes one component plane (ILV=0) directly into the
+// pixel-interleaved output as component c of nc, one reconstructed line at a
+// time. Only the two O(W) line buffers are held, so peak memory is independent
+// of image height (no W*H int plane).
+func (d *jlsDecoder) decodePlaneInto(output []byte, c, nc, bps int) {
 	W, H := d.f.width, d.f.height
 	d.runIndex = 0
 	prev := make([]int, W) // reconstructed line above (zero for first line)
@@ -457,7 +454,10 @@ func (d *jlsDecoder) decodePlane(plane []int) {
 
 	for y := 0; y < H; y++ {
 		rcLeft = d.decodeScalarLine(cur, prev, y, rcLeft)
-		copy(plane[y*W:y*W+W], cur)
+		row := y * W
+		for x := 0; x < W; x++ {
+			putSample(output, (row+x)*nc+c, cur[x], bps)
+		}
 		prev, cur = cur, prev
 	}
 }
@@ -524,10 +524,11 @@ func (d *jlsDecoder) decodeRunInterruption(ra, rb int) int {
 
 // decodeRIError decodes a run-interruption error for context q with nRItype.
 func (d *jlsDecoder) decodeRIError(q, nRItype int) int {
+	cs := &d.ctx[q]
 	// k: TEMP = A + (N>>1)*nRItype; smallest k with (N<<k) >= TEMP.
-	temp := d.a[q] + (d.n[q]>>1)*nRItype
+	temp := cs.a + (cs.n>>1)*nRItype
 	k := 0
-	for (d.n[q] << k) < temp {
+	for (cs.n << k) < temp {
 		k++
 	}
 	limit := d.limit - jlsRunJ[d.runIndex] - 1
@@ -538,7 +539,7 @@ func (d *jlsDecoder) decodeRIError(q, nRItype int) int {
 	mapFlag := t & 1
 	errAbs := (t + mapFlag) / 2
 	condition := 0
-	if k != 0 || 2*d.nn[q] >= d.n[q] {
+	if k != 0 || 2*cs.nn >= cs.n {
 		condition = 1
 	}
 	var errval int
@@ -550,15 +551,15 @@ func (d *jlsDecoder) decodeRIError(q, nRItype int) int {
 
 	// UpdateVariables(errval, EMErrval).
 	if errval < 0 {
-		d.nn[q]++
+		cs.nn++
 	}
-	d.a[q] += (emerr + 1 - nRItype) >> 1
-	if d.n[q] == d.f.reset {
-		d.a[q] >>= 1
-		d.n[q] >>= 1
-		d.nn[q] >>= 1
+	cs.a += (emerr + 1 - nRItype) >> 1
+	if cs.n == d.f.reset {
+		cs.a >>= 1
+		cs.n >>= 1
+		cs.nn >>= 1
 	}
-	d.n[q]++
+	cs.n++
 	return errval
 }
 


### PR DESCRIPTION
## Why

Viewing **JPEG-LS Lossless** images through `io-api` was crashing the backend. Investigation traced it to the pure-Go JPEG-LS decoder:

- **The crash was `OOMKilled` (exit 137).** The pod (512Mi limit) was killed mid-render. The non-interleaved decode path allocated a full `W*H` `[]int` intermediate — 8 bytes/sample, ~4× a 16-bit frame — which on large frames was the dominant allocation and tipped the process over its memory limit (compounded by Go's GC letting the heap grow ~2× the live set with no `GOMEMLIMIT`).
- **Decode was also slow** (~55 MB/s on a real CT frame).

## What changed

### Memory (the OOM fix)
`decodePlaneInto` now streams each reconstructed line directly into the interleaved output instead of building a full `W*H` int plane first. **Peak decode memory is now O(width) instead of O(width×height).** Output is byte-identical.

### Speed — ~1.75× faster
| Benchmark | Before | After |
|---|---|---|
| Real CT fixture (512², 16-bit) | 55 MB/s | **93 MB/s** |
| Synthetic 512² | 43 MB/s | **72 MB/s** |
| Synthetic 2048² | 43 MB/s | **76 MB/s** |

Profile-guided, in order of impact:
1. **Bit reader** rewritten around a 64-bit accumulator with bulk byte refill (JPEG-LS stuffed bits stripped once at fill time). `readBits` is a single shift; the unary Golomb prefix uses a hardware leading-zeros scan instead of one method call per bit.
2. **`quantize`** replaced with a precomputed lookup table indexed by the neighbor difference (built once per decode).
3. **Context model** (`a/b/c/n/nn`) merged from four separate slices into one struct-of-arrays (`ctxState`) so a context's fields share a cache line.
4. `decodeScalarLine` drops redundant per-pixel `y==0` branches (callers zero-init `prev` for row 0).

The encoder shares the decoder's context struct and was updated to match.

## Correctness
- Golden-vector tests (byte-exact vs CharLS reference) pass.
- Round-trip encode/decode tests pass.
- Full `./codecs/...` and `./media/...` suites pass.
- Adds a decode benchmark (`bench_test.go`) to guard against regressions.

## Deploy note
This lands in `io-api` only after an io-dicom/io-api **image rebuild** (io-api links io-dicom via local replace). As a separate operational mitigation, the `io-api` deployment memory limit was already raised 512Mi → 1Gi to stop the live crashes; this PR removes the underlying memory pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)