### PR TITLE
feat(media): stream object writes; fix wado frame retrieval above 512 MiB

### DIFF
--- a/media/dicom_buffer.go
+++ b/media/dicom_buffer.go
@@ -212,6 +212,17 @@ func (buf *DICOMBuffer) WriteTag(tag *DICOMTag, explicitVR bool) {
 }
 
 func (buf *DICOMBuffer) writeTag(tag *DICOMTag, explicitVR bool, ts *transfersyntax.TransferSyntax) {
+	writeLen := buf.writeTagHeader(tag, explicitVR, ts)
+	if (writeLen != 0) && (writeLen != 0xFFFFFFFF) {
+		buf.Write(tag.Data, int(writeLen))
+	}
+}
+
+// writeTagHeader writes tag's group/element/VR/length header and returns the
+// value length that header declares. Keeping the header separate from the value
+// lets DICOMObject.WriteTo stream a tag's data straight to an io.Writer instead
+// of copying every byte through this buffer.
+func (buf *DICOMBuffer) writeTagHeader(tag *DICOMTag, explicitVR bool, ts *transfersyntax.TransferSyntax) uint32 {
 	writeVR := normalizeExplicitVR(tag, ts)
 
 	// Derive the length to serialize from the actual data length to guarantee the
@@ -253,9 +264,7 @@ func (buf *DICOMBuffer) writeTag(tag *DICOMTag, explicitVR bool, ts *transfersyn
 	} else {
 		buf.WriteUint32(writeLen)
 	}
-	if (writeLen != 0) && (writeLen != 0xFFFFFFFF) {
-		buf.Write(tag.Data, int(writeLen))
-	}
+	return writeLen
 }
 
 // WriteStringTag - Writes a String to a DICOM tag

--- a/media/dicom_object.go
+++ b/media/dicom_object.go
@@ -94,6 +94,9 @@ type DICOMObject interface {
 	TagCount() int
 	WriteToBytes() []byte
 	WriteToFile(fileName string) error
+	// WriteTo serialises the object to w without buffering it whole; see the
+	// implementation for the one buffering exception (deflated datasets).
+	WriteTo(w io.Writer) (int64, error)
 }
 
 type dicomObject struct {
@@ -542,6 +545,88 @@ func (obj *dicomObject) WriteToBytes() []byte {
 	return obj.encodeToBytes()
 }
 
+// streamScratchFlushBytes is the size at which the tag-header scratch buffer is
+// flushed to the destination writer. Headers are ~12 bytes, so this batches
+// several hundred small tags into one Write while staying trivially small.
+const streamScratchFlushBytes = 8 << 10
+
+// WriteTo serialises the object to w, implementing io.WriterTo.
+//
+// Unlike WriteToBytes it never materialises the whole object: tag headers go
+// through a small scratch buffer and each tag's value is written straight from
+// the tag to w. Peak additional memory is therefore a few KiB rather than a
+// second full copy of the object, which matters for instances whose pixel data
+// runs to hundreds of megabytes.
+//
+// Deflated Explicit VR Little Endian is the one exception — that syntax deflates
+// the entire dataset as a unit, so it cannot be produced incrementally and falls
+// back to buffering.
+func (obj *dicomObject) WriteTo(w io.Writer) (int64, error) {
+	if err := ValidateFileWrite(obj); err != nil {
+		return 0, err
+	}
+
+	if obj.TransferSyntax.UID == transfersyntax.DeflatedExplicitVRLittleEndian.UID {
+		payload := obj.encodeToBytes()
+		if payload == nil {
+			return 0, errors.New("media: WriteTo: failed to encode deflated dataset")
+		}
+		n, err := w.Write(payload)
+		return int64(n), err
+	}
+
+	var written int64
+	scratch := NewDICOMBufferWithCapacity(streamScratchFlushBytes)
+	flush := func() error {
+		data := scratch.GetData()
+		if len(data) == 0 {
+			return nil
+		}
+		n, err := w.Write(data)
+		written += int64(n)
+		scratch.Clear()
+		return err
+	}
+
+	SOPClassUID := obj.GetString(tags.SOPClassUID)
+	SOPInstanceUID := obj.GetString(tags.SOPInstanceUID)
+	scratch.WriteMeta(SOPClassUID, SOPInstanceUID, obj.TransferSyntax.UID)
+	if err := flush(); err != nil {
+		return written, err
+	}
+	// File Meta Information is always little-endian per DICOM PS3.10 §10.1, so
+	// the dataset byte order is only applied once the meta header is out.
+	if obj.TransferSyntax.UID == transfersyntax.ExplicitVRBigEndian.UID {
+		scratch.SetBigEndian(true)
+	}
+
+	explicitVR := obj.IsExplicitVR()
+	for i := 0; i < obj.TagCount(); i++ {
+		tag := obj.GetTagAt(i)
+		writeLen := scratch.writeTagHeader(tag, explicitVR, obj.TransferSyntax)
+		if writeLen != 0 && writeLen != 0xFFFFFFFF {
+			// Flush the pending headers, then hand the value bytes to w directly
+			// so they are never copied into the scratch buffer.
+			if err := flush(); err != nil {
+				return written, err
+			}
+			n, err := w.Write(tag.Data[:writeLen])
+			written += int64(n)
+			if err != nil {
+				return written, err
+			}
+			continue
+		}
+		if scratch.GetSize() >= streamScratchFlushBytes {
+			if err := flush(); err != nil {
+				return written, err
+			}
+		}
+	}
+	err := flush()
+	return written, err
+}
+
 func ValidateFileWrite(obj DICOMObject) error {
 	if obj == nil {
 		return errors.New("media: cannot write nil DICOM object")
@@ -575,7 +660,17 @@ func (obj *dicomObject) WriteToFile(fileName string) error {
 	if err := ValidateFileWrite(obj); err != nil {
 		return err
 	}
-	return os.WriteFile(fileName, obj.encodeToBytes(), 0o600)
+	f, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	// Stream rather than buffering the whole object, so writing a large instance
+	// no longer needs a second full copy of it in memory.
+	if _, err := obj.WriteTo(f); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 // DateRange represents a DICOM date range query value (e.g. for C-FIND).

--- a/media/write_stream_test.go
+++ b/media/write_stream_test.go
@@ -1,0 +1,147 @@
+package media
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/dictionary/transfersyntax"
+)
+
+// TestWriteToMatchesWriteToBytes is the correctness contract for the streaming
+// writer: WriteTo must produce a byte-for-byte identical result to the buffering
+// WriteToBytes path, for every transfer syntax, including the deflated syntax
+// that WriteTo deliberately falls back to buffering for.
+func TestWriteToMatchesWriteToBytes(t *testing.T) {
+	samples := []string{"../testdata/test2.dcm", "../testdata/jpeg8.dcm"}
+	syntaxes := []*transfersyntax.TransferSyntax{
+		nil, // keep the file's own transfer syntax
+		transfersyntax.ExplicitVRLittleEndian,
+		transfersyntax.ImplicitVRLittleEndian,
+		transfersyntax.ExplicitVRBigEndian,
+		transfersyntax.DeflatedExplicitVRLittleEndian,
+	}
+
+	for _, sample := range samples {
+		if _, err := os.Stat(sample); err != nil {
+			t.Skipf("sample fixture unavailable (%s): %v", sample, err)
+		}
+		for _, ts := range syntaxes {
+			name := filepath.Base(sample) + "/original"
+			if ts != nil {
+				name = filepath.Base(sample) + "/" + ts.Name
+			}
+			t.Run(name, func(t *testing.T) {
+				obj, err := NewDCMObjFromFile(sample)
+				if err != nil {
+					t.Fatalf("NewDCMObjFromFile: %v", err)
+				}
+				if ts != nil {
+					obj.SetTransferSyntax(ts)
+				}
+
+				want := obj.WriteToBytes()
+				if len(want) == 0 {
+					t.Skip("object not serialisable under this transfer syntax")
+				}
+
+				var got bytes.Buffer
+				n, err := obj.WriteTo(&got)
+				if err != nil {
+					t.Fatalf("WriteTo: %v", err)
+				}
+				if n != int64(got.Len()) {
+					t.Fatalf("WriteTo reported %d bytes but wrote %d", n, got.Len())
+				}
+				if !bytes.Equal(want, got.Bytes()) {
+					t.Fatalf("streamed output differs from buffered: len want=%d got=%d, first diff at %d",
+						len(want), got.Len(), firstDiff(want, got.Bytes()))
+				}
+			})
+		}
+	}
+}
+
+// TestWriteToFileMatchesWriteToBytes covers the streaming WriteToFile path.
+func TestWriteToFileMatchesWriteToBytes(t *testing.T) {
+	const sample = "../testdata/test2.dcm"
+	if _, err := os.Stat(sample); err != nil {
+		t.Skipf("sample fixture unavailable: %v", err)
+	}
+	obj, err := NewDCMObjFromFile(sample)
+	if err != nil {
+		t.Fatalf("NewDCMObjFromFile: %v", err)
+	}
+	want := obj.WriteToBytes()
+
+	out := filepath.Join(t.TempDir(), "streamed.dcm")
+	if err := obj.WriteToFile(out); err != nil {
+		t.Fatalf("WriteToFile: %v", err)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(want, got) {
+		t.Fatalf("WriteToFile output differs from WriteToBytes: len want=%d got=%d, first diff at %d",
+			len(want), len(got), firstDiff(want, got))
+	}
+	// The streamed file must still round-trip back into an object.
+	if _, err := NewDCMObjFromFile(out); err != nil {
+		t.Fatalf("streamed file does not parse back: %v", err)
+	}
+}
+
+// BenchmarkWriteBuffered vs BenchmarkWriteStreamed contrast the two paths on the
+// same object. The streamed path should allocate a small constant amount
+// regardless of object size, while the buffered path allocates the whole object.
+func BenchmarkWriteBuffered(b *testing.B) {
+	obj := benchWriteObj(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if data := obj.WriteToBytes(); len(data) == 0 {
+			b.Fatal("empty payload")
+		}
+	}
+}
+
+func BenchmarkWriteStreamed(b *testing.B) {
+	obj := benchWriteObj(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := obj.WriteTo(discardWriter{}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// discardWriter avoids io.Discard's ReadFrom fast path so both benchmarks
+// measure the same work.
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func benchWriteObj(b *testing.B) DICOMObject {
+	b.Helper()
+	obj, err := NewDCMObjFromFile("../testdata/test2.dcm")
+	if err != nil {
+		b.Skipf("sample fixture unavailable: %v", err)
+	}
+	return obj
+}
+
+func firstDiff(a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return n
+}

--- a/wado/server.go
+++ b/wado/server.go
@@ -241,8 +241,14 @@ func (s *wadoServer) retrieveFrames(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", fmt.Sprintf(
 		`multipart/related; type="application/octet-stream"; boundary=%s`, mw.Boundary()))
 	for _, f := range frames {
-		data, pixErr := obj.GetPixelData(f - 1) // convert to 0-based
+		// GetDecompressedFrame, not GetPixelData: the latter sizes (and caps) its
+		// allocation across ALL frames, so any object whose total pixel data
+		// exceeds the 512 MiB cap failed on every frame and produced an empty
+		// 200 response. It also returns raw compressed fragments for encapsulated
+		// syntaxes, whereas WADO-RS octet-stream frames are uncompressed.
+		data, pixErr := obj.GetDecompressedFrame(r.Context(), f-1) // convert to 0-based
 		if pixErr != nil {
+			slog.Warn("wado: failed to read frame", "frame", f, "err", pixErr)
 			continue
 		}
 		part, partErr := mw.CreatePart(textproto.MIMEHeader{
@@ -357,15 +363,14 @@ func writeMultipartDICOM(w http.ResponseWriter, objects []media.DICOMObject) {
 		if partErr != nil {
 			break
 		}
-		payload := obj.WriteToBytes()
-		if len(payload) == 0 {
+		// Stream straight into the multipart part: buffering the object first
+		// would hold a second full copy of its pixel data in memory.
+		if _, writeErr := obj.WriteTo(part); writeErr != nil {
 			if err := media.ValidateFileWrite(obj); err != nil {
 				slog.Warn("wado: DICOM object not serializable", "err", err)
+			} else {
+				slog.Warn("wado: failed to write DICOM object", "err", writeErr)
 			}
-			break
-		}
-		if _, writeErr := part.Write(payload); writeErr != nil {
-			slog.Warn("wado: failed to write DICOM object", "err", writeErr)
 			break
 		}
 	}


### PR DESCRIPTION
## Summary

Two independent improvements found during the perf/memory audit. Both are measured, not estimated.

| Change | Measured |
|---|---|
| `DICOMObject.WriteTo(io.Writer)` — streaming serialisation | **532,688 → 8,400 B/op (−98.4%)**, 13.4× faster |
| wado frame retrieval bug | fixes **silent empty 200** above 512 MiB |
| wado instance retrieval streams | no full copy per multipart part |

### 1. `media`: streaming object writes

Serialising an object always went through `WriteToBytes`, which materialises the **entire object — pixel data included — in a second buffer**. `writeTag` is now split into a header write plus a value write, so `WriteTo` pushes tag headers through a small scratch buffer and hands each tag's value bytes **straight to the destination writer**.

```
write test2.dcm:  532688 -> 8400 B/op (-98.4%),  47792 -> 3557 ns/op (13.4x)
```

The streamed figure is just the scratch buffer and **does not grow with the object** — a 500 MB instance goes from ~500 MB of transient copy to ~8 KB.

`WriteToFile` now streams to the file handle rather than building the whole payload for `os.WriteFile`.

**Deflated Explicit VR Little Endian deliberately still buffers** — that syntax deflates the dataset as a unit and cannot be produced incrementally.

**Correctness contract:** `media/write_stream_test.go` asserts `WriteTo` output is **byte-for-byte identical** to `WriteToBytes` across explicit VR, implicit VR, big-endian, and the deflated fallback (2 fixtures × 5 transfer syntaxes), and that the streamed file parses back.

### 2. wado: `retrieveFrames` returned an empty 200 for large multi-frame objects — bug

The handler called `GetPixelData` per frame. That accessor sizes **and caps** its allocation across **all** frames:

```
sizePx = cols*rows*bitsa/8 (x3 if RGB) * frames
if sizePx > maxPixelDataBytes -> error       // 512 MiB
```

So any uncompressed object whose *total* pixel data exceeded 512 MiB failed on **every** frame — and the loop did `continue` on error, so the client got an **empty multipart body with HTTP 200 and nothing logged**. 512 MiB is reachable in practice: 512×512×16-bit × 1000 frames ≈ 524 MB; enhanced multi-frame CT/MR and 4D datasets hit it.

Now uses `GetDecompressedFrame` (caps **per frame**) and logs failures rather than silently skipping.

⚠️ **Behaviour change worth a reviewer's eye:** `GetPixelData` returned *raw compressed fragments* for encapsulated syntaxes; `GetDecompressedFrame` decompresses. WADO-RS frames served as `application/octet-stream` are expected to be uncompressed, so the previous behaviour was non-conformant — but this does change bytes on the wire for compressed objects.

### 3. wado: stream instances into their multipart part

`retrieveInstances` buffered each object via `WriteToBytes` before writing it; it now writes through `WriteTo`, so no full copy is held per part.

## Compatibility note

`WriteTo` is added to the public `DICOMObject` interface. That is source-breaking for any **explicit** implementer (embedders are unaffected). All three in-repo consumers — **io-scp**, **io-router**, **go-bridge** — build, vet and test green against the widened interface; io-scp's test double embeds the interface, so it needed no change.

## Testing
- Full suite green; `-race` clean on `media/` and `wado/`; `go vet` clean
- Byte-equality test across 10 file × transfer-syntax combinations
- All three consumers build, vet, and test green

## Relationship to #29
Independent of [#29](https://github.com/innovative-io/io-dicom/pull/29) and branched from `main`, so the two can merge in either order. They touch different regions of `media/dicom_object.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)