### PR TITLE
perf(jpeg2000): single-pass neighbour scan and pooled tier-1 buffers

### DIFF
--- a/codecs/jpeg2000/gojp2k_tier1.go
+++ b/codecs/jpeg2000/gojp2k_tier1.go
@@ -1,5 +1,7 @@
 package jpeg2000
 
+import "sync"
+
 // Tier-1 EBCOT code-block decoding (ITU-T T.800 Annex D): decode each
 // code-block's MQ-coded segment, bit-plane by bit-plane, through the three
 // coding passes (significance propagation, magnitude refinement, cleanup) with
@@ -62,12 +64,61 @@ func (t *t1) signContrib(x, y int) int {
 	return 1
 }
 
+// neighborCounts returns the horizontal, vertical and diagonal significant
+// neighbour counts for (x,y) in one pass.
+//
+// Row bases are computed once per row and the bounds tests are done per
+// row/column rather than per neighbour. The previous form issued eight separate
+// sigAt calls, each repeating four comparisons plus a slice bounds check, which
+// made sigAt the hottest function in JPEG 2000 decoding (33.7% flat CPU).
+func (t *t1) neighborCounts(x, y int) (hc, vc, dc int) {
+	w := t.w
+	left := x > 0
+	right := x+1 < w
+
+	if y > 0 {
+		row := (y-1)*w + x
+		if t.sig[row] {
+			vc++
+		}
+		if left && t.sig[row-1] {
+			dc++
+		}
+		if right && t.sig[row+1] {
+			dc++
+		}
+	}
+	row := y*w + x
+	if left && t.sig[row-1] {
+		hc++
+	}
+	if right && t.sig[row+1] {
+		hc++
+	}
+	if y+1 < t.h {
+		row := (y+1)*w + x
+		if t.sig[row] {
+			vc++
+		}
+		if left && t.sig[row-1] {
+			dc++
+		}
+		if right && t.sig[row+1] {
+			dc++
+		}
+	}
+	return hc, vc, dc
+}
+
 // zcContext computes the zero-coding (significance) context (T.800 Table D.1).
 func (t *t1) zcContext(x, y int) int {
-	h := b2i(t.sigAt(x-1, y)) + b2i(t.sigAt(x+1, y))
-	v := b2i(t.sigAt(x, y-1)) + b2i(t.sigAt(x, y+1))
-	d := b2i(t.sigAt(x-1, y-1)) + b2i(t.sigAt(x+1, y-1)) + b2i(t.sigAt(x-1, y+1)) + b2i(t.sigAt(x+1, y+1))
+	h, v, d := t.neighborCounts(x, y)
+	return t.zcContextFromCounts(h, v, d)
+}
 
+// zcContextFromCounts maps already-computed neighbour counts to a ZC context,
+// so a caller that has scanned the neighbourhood does not scan it again.
+func (t *t1) zcContextFromCounts(h, v, d int) int {
 	switch t.orient {
 	case bandHL:
 		h, v = v, h // HL swaps horizontal/vertical roles
@@ -177,8 +228,8 @@ func (t *t1) decodeSign(x, y int) {
 }
 
 func (t *t1) anyNeighborSignificant(x, y int) bool {
-	return t.sigAt(x-1, y) || t.sigAt(x+1, y) || t.sigAt(x, y-1) || t.sigAt(x, y+1) ||
-		t.sigAt(x-1, y-1) || t.sigAt(x+1, y-1) || t.sigAt(x-1, y+1) || t.sigAt(x+1, y+1)
+	h, v, d := t.neighborCounts(x, y)
+	return h+v+d != 0
 }
 
 // sigPropPass: significance propagation (T.800 D.3.1).
@@ -188,10 +239,17 @@ func (t *t1) sigPropPass(bp int) {
 			for y := y0; y < y0+4 && y < t.h; y++ {
 				i := t.idx(x, y)
 				t.visited[i] = false
-				if t.sig[i] || !t.anyNeighborSignificant(x, y) {
+				if t.sig[i] {
 					continue
 				}
-				if t.mq.decode(&t.cx[t.zcContext(x, y)]) == 1 {
+				// One neighbourhood scan serves both the significance test and
+				// the ZC context; previously this walked the same eight
+				// neighbours twice per coefficient.
+				hc, vc, dc := t.neighborCounts(x, y)
+				if hc+vc+dc == 0 {
+					continue
+				}
+				if t.mq.decode(&t.cx[t.zcContextFromCounts(hc, vc, dc)]) == 1 {
 					t.decodeSign(x, y)
 					t.sig[i] = true
 					t.mag[i] |= 1 << uint(bp)
@@ -273,6 +331,54 @@ func (t *t1) cleanupPass(bp int) {
 // the second return value is the lowest decoded bit-plane, which the caller uses
 // to add the reconstruction mid-point (T.800 E.1.1) appropriately for the
 // reversible (integer) or irreversible (float) path.
+// t1Pool recycles the five per-code-block work buffers. A decode allocated all
+// of them fresh for every code-block, which made decodeCodeBlock ~51% of all
+// bytes allocated and left ~14% of decode CPU in runtime.madvise returning the
+// churn to the OS. A sync.Pool is used rather than shared scratch state because
+// frames are decoded concurrently by runFrameJobs, so any single shared buffer
+// would be a data race.
+//
+// Only buffers that stay internal to decodeCodeBlock are pooled; the slice it
+// returns is always freshly allocated, since the caller retains it.
+var t1Pool = sync.Pool{New: func() any { return new(t1) }}
+
+func reuseBools(b []bool, n int) []bool {
+	if cap(b) < n {
+		return make([]bool, n)
+	}
+	b = b[:n]
+	clear(b)
+	return b
+}
+
+func reuseInt32s(b []int32, n int) []int32 {
+	if cap(b) < n {
+		return make([]int32, n)
+	}
+	b = b[:n]
+	clear(b)
+	return b
+}
+
+func acquireT1(w, h, orient int, data []byte) *t1 {
+	t := t1Pool.Get().(*t1)
+	n := w * h
+	t.w, t.h, t.orient = w, h, orient
+	t.sig = reuseBools(t.sig, n)
+	t.sign = reuseBools(t.sign, n)
+	t.visited = reuseBools(t.visited, n)
+	t.refined = reuseBools(t.refined, n)
+	t.mag = reuseInt32s(t.mag, n)
+	t.cx = initContexts()
+	t.mq = newMQDecoder(data, 0, len(data))
+	return t
+}
+
+func releaseT1(t *t1) {
+	t.mq = nil // don't pin the coded segment
+	t1Pool.Put(t)
+}
+
 func decodeCodeBlock(cb *codeBlock, orient, mb int) ([]int32, int) {
 	w, h := cb.w(), cb.h()
 	if w <= 0 || h <= 0 || cb.npasses == 0 || len(cb.segs) == 0 {
@@ -287,20 +393,13 @@ func decodeCodeBlock(cb *codeBlock, orient, mb int) ([]int32, int) {
 			data = append(data, s...)
 		}
 	}
-	t := &t1{
-		w: w, h: h, orient: orient,
-		sig:     make([]bool, w*h),
-		sign:    make([]bool, w*h),
-		mag:     make([]int32, w*h),
-		visited: make([]bool, w*h),
-		refined: make([]bool, w*h),
-		cx:      initContexts(),
-		mq:      newMQDecoder(data, 0, len(data)),
-	}
+	t := acquireT1(w, h, orient, data)
+	defer releaseT1(t)
 
 	bpStart := mb - 1 - cb.nzeroBP
 	if bpStart < 0 {
-		return t.mag, 0
+		// t.mag is pooled and must not escape; it is still all zeros here.
+		return make([]int32, w*h), 0
 	}
 	bp := bpStart
 	passNo := 0


### PR DESCRIPTION
## Summary

Follow-up to **#31**, which profiled the DWT fix and found the DWT was *not* the bottleneck — tier-1 EBCOT is:

```
33.72% flat  t1.sigAt
27.91% cum   t1.sigPropPass
13.95% flat  runtime.madvise      <- per-code-block allocation churn
```

This addresses both halves.

### 1. Single-pass neighbour scan

`sigAt` repeated four comparisons plus a bounds check on **every** call, and was called 8× from `zcContext`, 8× from `anyNeighborSignificant`, 8× from `mrContext`. Worse, `sigPropPass` called `anyNeighborSignificant` **and then** `zcContext` for the same coefficient — walking the identical eight neighbours **twice**.

`neighborCounts` now returns the h/v/d counts in one pass, with row bases hoisted and bounds tests done per row/column rather than per neighbour. `zcContext` splits into a thin wrapper plus `zcContextFromCounts`, so `sigPropPass` scans once and feeds both the significance test and the context lookup.

### 2. Pooled per-code-block buffers

Every code-block allocated `sig`, `sign`, `mag`, `visited`, `refined` fresh — `decodeCodeBlock` was ~51% of all bytes allocated, and ~14% of decode CPU was `madvise` handing the churn back to the OS.

Now recycled through a `sync.Pool`. **A pool rather than shared scratch state is required** — `runFrameJobs` decodes frames concurrently, so a single shared buffer would be a data race. Only buffers that stay internal are pooled: the slice `decodeCodeBlock` returns is always freshly allocated because the caller retains it, and the early `bpStart<0` path now allocates instead of handing back the pooled `t.mag`.

## Measured

Against the same benchmarks with #31 already applied:

| benchmark | time | bytes/op | allocs/op |
|---|---|---|---|
| lossless gray8 512 | 38.18 → **32.91 ms** | | 943 → **607** |
| lossless gray16 512 | 20.89 → **18.31 ms** | 5,634,477 → **3,583,602** | 938 → **606** |
| lossless RGB8 512 | 111.13 → **97.83 ms** | 16,902,349 → **10,676,938** | 2,804 → **1,783** |
| lossy gray16 512 | 21.30 → **18.35 ms** | 5,634,472 → **3,583,602** | 938 → **606** |
| lossy RGB8 512 | 112.96 → **100.08 ms** | 16,902,392 → **10,676,200** | 2,804 → **1,782** |
| lossless gray16 1024 | 81.48 → **72.95 ms** | 22,476,373 → **14,121,402** | 2,492 → **1,210** |

**~10–14% faster, ~36% fewer bytes, 35–51% fewer allocations.**

## Correctness

- **Byte-exact** — existing golden and round-trip tests pass unchanged
- **`-race` clean** across `jpeg2000`, `transcoder` and `media`. The transcoder run matters specifically: it exercises the concurrent multi-frame path (`runFrameJobs`) that makes the pooling safety argument load-bearing.
- All three consumers build: io-scp, io-router, go-bridge

## Still open in tier-1

`sigAt` is reduced but not eliminated. Storing `sig`/`sign` with a 1-sample false border (stride `w+2`) would make it a bare index with no bounds check at all — a larger change touching ~25 access sites, deliberately not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)