### PR TITLE
perf(network): cut receive-path allocation ~62% on message accumulation

### DIFF
--- a/media/buffer_accumulate_benchmark_test.go
+++ b/media/buffer_accumulate_benchmark_test.go
@@ -1,0 +1,52 @@
+package media
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkBufferAccumulate mirrors the DICOM receive path: pdu_service resets
+// the P-DATA buffer per message and then appends every inbound PDV fragment
+// into it. Reset deliberately drops the backing array (callers may hold
+// zero-copy sub-slices of the previous message), so the buffer re-grows from
+// nothing on every message and the growth factor decides how much of a C-STORE
+// is spent reallocating and copying.
+//
+// The reported B/op is the true cost of accumulating msgSize bytes; anything
+// well above msgSize is regrowth waste.
+func benchAccumulate(b *testing.B, msgSize, fragment int) {
+	chunk := make([]byte, fragment)
+	buf := NewDICOMBuffer()
+
+	b.SetBytes(int64(msgSize))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		for written := 0; written < msgSize; written += fragment {
+			n := fragment
+			if written+n > msgSize {
+				n = msgSize - written
+			}
+			if _, err := buf.Write(chunk[:n], n); err != nil {
+				b.Fatalf("Write: %v", err)
+			}
+		}
+		if buf.GetSize() != msgSize {
+			b.Fatalf("got %d bytes, want %d", buf.GetSize(), msgSize)
+		}
+	}
+}
+
+func BenchmarkBufferAccumulate(b *testing.B) {
+	// 16 KiB fragments is the negotiated P-DATA-TF maximum.
+	for _, mb := range []int{1, 4, 16} {
+		b.Run(fmt.Sprintf("%dMiB_16KiBfrags", mb), func(b *testing.B) {
+			benchAccumulate(b, mb<<20, 16<<10)
+		})
+	}
+	// 4 KiB is the default send-side block size, so a peer may fragment that small.
+	b.Run("4MiB_4KiBfrags", func(b *testing.B) {
+		benchAccumulate(b, 4<<20, 4<<10)
+	})
+}

--- a/media/dicom_buffer_stream.go
+++ b/media/dicom_buffer_stream.go
@@ -156,9 +156,22 @@ func (buf *DICOMBuffer) Write(buffer []byte, count int) (int, error) {
 			// Extend within pre-allocated capacity — zero allocation.
 			buf.data = buf.data[:endPos]
 		} else {
-			// Must grow beyond current capacity; fall back to append.
-			grow := endPos - len(buf.data)
-			buf.data = append(buf.data, make([]byte, grow)...)
+			// Grow with explicit capacity doubling. Deferring to append meant
+			// inheriting its growth factor, which tapers toward ~1.25x for large
+			// slices — accumulating a multi-megabyte message from small fragments
+			// (exactly what the P-DATA receive path does after Reset drops the
+			// backing array) then cost roughly 5x the final size in allocation
+			// and copying.
+			newCap := cap(buf.data) * 2
+			if newCap < endPos {
+				newCap = endPos
+			}
+			if newCap < 4096 {
+				newCap = 4096
+			}
+			grown := make([]byte, endPos, newCap)
+			copy(grown, buf.data)
+			buf.data = grown
 		}
 	}
 

--- a/network/pdu_service.go
+++ b/network/pdu_service.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -127,6 +128,12 @@ type pduService struct {
 	implClassUID                 string
 	implVersion                  string
 	logger                       *slog.Logger
+	// hdrScratch backs the 10-byte PDU header read. It cannot be a local in
+	// readIncomingPDU: passing a local's slice to io.ReadFull's io.Reader
+	// interface makes escape analysis heap-allocate it, which cost one
+	// allocation per inbound PDU. One association is read by a single
+	// goroutine, so sharing it across calls is safe.
+	hdrScratch [10]byte
 }
 
 // NewPDUService creates a PDUService. Pass PDUServiceOption values to
@@ -644,23 +651,17 @@ func (pdu *pduService) emitRawPDU(direction RawPDUDirection, pduType byte, data 
 }
 
 func (pdu *pduService) readIncomingPDU() (byte, []byte, error) {
-	var header [10]byte
+	header := &pdu.hdrScratch
 	if _, err := io.ReadFull(pdu.readWriter, header[:]); err != nil {
 		return 0, nil, err
 	}
 
-	headerStream := media.NewDICOMBufferFromBytes(header[:])
-	itemType, err := headerStream.GetByte()
-	if err != nil {
-		return 0, nil, err
-	}
-	if _, err := headerStream.GetByte(); err != nil {
-		return 0, nil, err
-	}
-	pduLength, err := headerStream.ReadUint32(true)
-	if err != nil {
-		return 0, nil, err
-	}
+	// Decode the fixed header directly. Wrapping it in a DICOMBuffer just to
+	// read three fields cost three bounds-checked method calls per PDU for no
+	// benefit — the layout here is fixed by PS3.8 §9.3: item type, one reserved
+	// byte, then a big-endian uint32 length.
+	itemType := header[0]
+	pduLength := binary.BigEndian.Uint32(header[2:6])
 	if pduLength < 4 {
 		return 0, nil, fmt.Errorf("pdu: malformed PDU length %d (minimum is 4)", pduLength)
 	}


### PR DESCRIPTION
## Summary

The P-DATA receive path allocated roughly **5× the size of every inbound message**. Two independent causes, both measured with a new in-tree benchmark.

### 1. Buffer growth — the dominant cost

`pdu_service` resets the P-DATA buffer per message and appends each inbound PDV fragment into it. `Reset` **deliberately** drops the backing array — callers may hold zero-copy sub-slices of the previous message — so accumulation always restarts from zero capacity. `DICOMBuffer.Write` then deferred to `append`, whose growth factor tapers toward ~1.25× for large slices, so building an N-byte message from 16 KiB fragments cost **~5N** in allocation and memcpy.

Now grows by explicit capacity doubling:

| message | fragments | before B/op | after B/op | allocs | time |
|---|---|---|---|---|---|
| 1 MiB | 16 KiB | 5,447,959 | **2,081,306** | 14 → 7 | −41% |
| 4 MiB | 16 KiB | 22,397,243 | **8,372,248** | 21 → 9 | −61% |
| 16 MiB | 16 KiB | 87,286,116 | **33,538,059** | 27 → 11 | −63% |
| 4 MiB | 4 KiB | 21,076,524 | **8,384,818** | 25 → 11 | −65% |

**~62% fewer bytes, ~60% fewer allocations.** A 500 MB C-STORE study sheds roughly **1.6 GB** of allocation and the matching memcpy.

`Reset`'s safety invariant is untouched — the array is still dropped, only the regrowth schedule changes.

### 2. Per-PDU header allocation

`readIncomingPDU` declared `var header [10]byte` and passed `header[:]` to `io.ReadFull`. Because bufio's reader is consumed through the `io.Reader` **interface**, escape analysis moved the array to the heap — **one allocation per inbound PDU**, confirmed by `go build -gcflags=-m` before and after:

```
before:  network/pdu_service.go:647:6: moved to heap: header
after:   (no longer reported)
```

Now backed by a `pduService` field; one association is read by a single goroutine, so sharing across calls is safe. This is the **receive-side twin** of the `writePDVHeader` fix in #29.

Also decodes the header directly with `binary.BigEndian` instead of wrapping it in a `DICOMBuffer` to read three fields — the layout is fixed by PS3.8 §9.3.

## Benchmark

Adds `media/buffer_accumulate_benchmark_test.go`, reproducing the receive pattern (`Reset`, then fragment-sized writes) across message sizes and both 16 KiB and 4 KiB fragmentation, so this cannot silently regress.

## Testing
- Full suite green; `-race` clean on `network`, `media`, `transcoder`; `go vet` clean
- All three consumers build: io-scp, io-router, go-bridge

## Deliberately not included

The audit also flagged **pooling the per-PDU `data` buffer** (a second ~17% of receive bytes). Its safety depends on every consumer copying before the next PDU is read — including `emitRawPDU`, `ReadDynamic`'s zero-copy `ReadSlice`, and all association-PDU readers. That's a wide blast radius for data corruption in medical imaging, so it belongs in its own change with a per-consumer audit rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)