### PR TITLE
fix(deflate): bound decompression to prevent a remote OOM (zip bomb)

### DIFF
--- a/codecs/deflate/bomb_test.go
+++ b/codecs/deflate/bomb_test.go
@@ -1,0 +1,101 @@
+package deflate
+
+import (
+	"bytes"
+	"compress/zlib"
+	"strings"
+	"testing"
+)
+
+// makeBomb returns a zlib stream that inflates to n bytes of zeros. Highly
+// compressible input yields a very small payload for a very large output.
+func makeBomb(t *testing.T, n int) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw, err := zlib.NewWriterLevel(&buf, zlib.BestCompression)
+	if err != nil {
+		t.Fatalf("NewWriterLevel: %v", err)
+	}
+	zeros := make([]byte, 1<<20)
+	for written := 0; written < n; written += len(zeros) {
+		chunk := zeros
+		if n-written < len(chunk) {
+			chunk = zeros[:n-written]
+		}
+		if _, err := zw.Write(chunk); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestInflateFrameRejectsDecompressionBomb pins the bound on the unknown-size
+// path. media's dataset parser calls InflateFrame(data, -1) on the remainder of
+// the file, before any validation, so an unbounded read there is reachable
+// directly from the wire: a sub-megabyte instance could inflate to gigabytes and
+// exhaust memory on a C-STORE receiver.
+func TestInflateFrameRejectsDecompressionBomb(t *testing.T) {
+	// One byte over the cap is enough to prove the bound without allocating
+	// anything close to it in the success path.
+	bomb := makeBomb(t, MaxInflatedBytes+1)
+	t.Logf("compressed %d bytes -> declared %d bytes (%.0f:1)",
+		len(bomb), MaxInflatedBytes+1, float64(MaxInflatedBytes+1)/float64(len(bomb)))
+
+	out, err := InflateFrame(bomb, -1)
+	if err == nil {
+		t.Fatalf("expected the oversized stream to be rejected, got %d bytes", len(out))
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected a size-cap error, got %v", err)
+	}
+}
+
+// TestInflateFrameUnknownSizeUnderCap confirms the bound does not reject
+// legitimate streams.
+func TestInflateFrameUnknownSizeUnderCap(t *testing.T) {
+	payload := bytes.Repeat([]byte("DICOM"), 200000) // ~1 MB, well under the cap
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	if _, err := zw.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	zw.Close()
+
+	out, err := InflateFrame(buf.Bytes(), -1)
+	if err != nil {
+		t.Fatalf("InflateFrame(-1) on a legitimate stream: %v", err)
+	}
+	if !bytes.Equal(out, payload) {
+		t.Fatal("round-trip mismatch on the unknown-size path")
+	}
+}
+
+// TestInflateFrameExactSizeRejectsOverlong ensures the known-size path still
+// rejects a stream longer than declared, now that it reads exactly expectedSize
+// rather than everything.
+func TestInflateFrameExactSizeRejectsOverlong(t *testing.T) {
+	payload := []byte("0123456789ABCDEF")
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	if _, err := zw.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	zw.Close()
+
+	if _, err := InflateFrame(buf.Bytes(), len(payload)-1); err == nil {
+		t.Fatal("expected an error when the stream is longer than expectedSize")
+	}
+	if _, err := InflateFrame(buf.Bytes(), len(payload)+1); err == nil {
+		t.Fatal("expected an error when the stream is shorter than expectedSize")
+	}
+	out, err := InflateFrame(buf.Bytes(), len(payload))
+	if err != nil {
+		t.Fatalf("exact size should succeed: %v", err)
+	}
+	if !bytes.Equal(out, payload) {
+		t.Fatal("round-trip mismatch on the exact-size path")
+	}
+}

--- a/codecs/deflate/deflate.go
+++ b/codecs/deflate/deflate.go
@@ -20,6 +20,20 @@ func DeflateFrame(in []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// MaxInflatedBytes bounds how much data InflateFrame will materialise when the
+// caller cannot state the expected size.
+//
+// Without a bound, a small crafted payload inflates without limit: 261 KB of
+// input expands to 268 MB (about 1029:1), so a sub-megabyte hostile instance
+// could exhaust memory on any receiver that parses untrusted objects. The
+// dataset-level call in media's parser passes -1, and runs before validation,
+// so that path was reachable straight off the wire. 512 MiB mirrors the
+// pixel-data ceiling media already enforces.
+const MaxInflatedBytes = 512 << 20
+
+// InflateFrame decompresses a zlib stream. When expectedSize is non-negative it
+// is treated as the exact expected output length; pass -1 when the size is not
+// known ahead of time, in which case output is capped at MaxInflatedBytes.
 func InflateFrame(in []byte, expectedSize int) ([]byte, error) {
 	zr, err := zlib.NewReader(bytes.NewReader(in))
 	if err != nil {
@@ -27,12 +41,29 @@ func InflateFrame(in []byte, expectedSize int) ([]byte, error) {
 	}
 	defer zr.Close()
 
-	out, err := io.ReadAll(zr)
+	if expectedSize >= 0 {
+		// Exact size known: read precisely that much, then probe for trailing
+		// bytes so an oversized stream is still rejected rather than silently
+		// truncated. This also avoids io.ReadAll's growing buffer entirely.
+		out := make([]byte, expectedSize)
+		if _, err := io.ReadFull(zr, out); err != nil {
+			return nil, fmt.Errorf("ERROR, invalid deflated frame size")
+		}
+		var probe [1]byte
+		if n, _ := io.ReadFull(zr, probe[:]); n > 0 {
+			return nil, fmt.Errorf("ERROR, invalid deflated frame size")
+		}
+		return out, nil
+	}
+
+	// Size unknown: read at most one byte past the cap so an over-long stream is
+	// detected instead of being silently truncated at the limit.
+	out, err := io.ReadAll(io.LimitReader(zr, MaxInflatedBytes+1))
 	if err != nil {
 		return nil, err
 	}
-	if expectedSize >= 0 && len(out) != expectedSize {
-		return nil, fmt.Errorf("ERROR, invalid deflated frame size")
+	if len(out) > MaxInflatedBytes {
+		return nil, fmt.Errorf("ERROR, deflated stream exceeds %d bytes", MaxInflatedBytes)
 	}
 	return out, nil
 }


### PR DESCRIPTION
## ⚠️ Security: remotely-triggerable memory exhaustion

`InflateFrame` called `io.ReadAll` on the zlib stream and only compared the result against `expectedSize` **afterwards** — so the entire decompressed payload was materialised before any size check. The dataset-level caller passes `-1`, meaning **no bound at all**:

```go
media/dicom_object.go:243   deflate.InflateFrame(deflatedData, -1)
```

That runs inside `parseDICOMBuffer` — on the remainder of the file, on **every** `NewDCMObjFromBytes`/`NewDCMObjFromFile`, **before validation**. Any receiver parsing untrusted objects (a C-STORE SCP, STOW-RS, an index walk) could be made to allocate without limit by a small crafted instance using `DeflatedExplicitVRLittleEndian`.

**Measured amplification: 521,821 compressed bytes declare 536,870,913 bytes of output — about 1029:1.** A sub-megabyte instance suffices to exhaust memory, and `io.ReadAll`'s growing buffer pushes the transient peak higher still.

## Fix

Both paths are now bounded:

- **`expectedSize >= 0`** — read exactly that many bytes with `io.ReadFull`, then probe for trailing data so an over-long stream is still rejected. This also removes `io.ReadAll`'s growing buffer from the framed path entirely.
- **`expectedSize < 0`** — cap at `MaxInflatedBytes` (512 MiB, mirroring the pixel-data ceiling media already enforces), reading one byte past the cap so an over-long stream **errors** rather than being silently truncated.

## Tests

`bomb_test.go` pins all three behaviours:

```
--- PASS: TestInflateFrameRejectsDecompressionBomb
    compressed 521821 bytes -> declared 536870913 bytes (1029:1)
--- PASS: TestInflateFrameUnknownSizeUnderCap        (legitimate stream still round-trips)
--- PASS: TestInflateFrameExactSizeRejectsOverlong   (rejects both short and long)
```

The pre-existing `TestInflateFrameWrongSize` still passes.

Full suite green, `go vet` clean, all three consumers build (io-scp, io-router, go-bridge).

## Context

Found by an audit of the codec files an earlier pass had skipped by file-glob. That same audit surfaced further issues not addressed here — most notably JPIP encode being broken for **all** multi-frame images, 16-bit colour RLE producing streams this library's own decoder rejects, and `RLEencode` never emitting replicate runs (so "RLE Lossless" output is always *larger* than its input). Those are behavioural bugs rather than a security issue and are being triaged separately; this PR is deliberately scoped to the memory-exhaustion fix so it can land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)