### PR TITLE
fix(jpeg): consume RSTn markers so restart intervals decode correctly

### DIFF
--- a/codecs/jpeg/gojpeg_lossless.go
+++ b/codecs/jpeg/gojpeg_lossless.go
@@ -166,15 +166,51 @@ func extend(v, t int) int {
 	return v
 }
 
-// reset clears the bit accumulator and clears a consumed restart marker so
-// decoding can continue after RSTn.
+// restart clears the bit accumulator at a restart-interval boundary and
+// consumes the RSTn marker that terminates the interval, so decoding can
+// continue with the next interval.
+//
+// Both cases matter. If a previous fill() already latched the marker, it is
+// consumed from the latched state. Otherwise the accumulator still held buffered
+// bits when the boundary was reached, so no fill() has looked at the marker yet
+// and br.pos still sits at (or just before) it — the marker must be located and
+// skipped here.
+//
+// Handling only the latched case silently corrupted every conforming file that
+// uses restart intervals: the marker was never consumed, the next fill() latched
+// it and returned false, and from then on readBit returned 0 forever, so every
+// interval after the first decoded as padding with no error reported.
 func (br *bitReader) restart() {
 	br.bits = 0
 	br.nbits = 0
-	if br.atMarker && br.marker >= 0xD0 && br.marker <= 0xD7 {
-		br.pos += 2 // consume the RSTn marker
-		br.atMarker = false
-		br.marker = 0
+
+	if br.atMarker {
+		if br.marker >= 0xD0 && br.marker <= 0xD7 {
+			br.pos += 2 // consume the RSTn marker
+			br.atMarker = false
+			br.marker = 0
+		}
+		return
+	}
+
+	// Scan forward for the RSTn. Any bytes in between are the encoder's pad bits
+	// (T.81 E.1.1 requires padding to a byte boundary before the marker); stuffed
+	// 0xFF00 sequences are skipped. A marker that is not an RSTn ends the scan and
+	// is left for the caller's normal marker handling.
+	for i := br.pos; i+1 < len(br.data); i++ {
+		if br.data[i] != 0xFF {
+			continue
+		}
+		next := br.data[i+1]
+		if next >= 0xD0 && next <= 0xD7 {
+			br.pos = i + 2
+			br.atMarker = false
+			br.marker = 0
+			return
+		}
+		if next != 0x00 { // a real, non-restart marker: stop here
+			return
+		}
 	}
 }
 

--- a/codecs/jpeg/restart_test.go
+++ b/codecs/jpeg/restart_test.go
@@ -1,0 +1,68 @@
+package jpeg
+
+import (
+	"bytes"
+	"testing"
+)
+
+// buildLosslessWithRestarts assembles a conforming 4x2, 8-bit, single-component
+// lossless (SOF3) JPEG that uses a restart interval of 4 — i.e. one RST marker
+// between the two rows.
+//
+// The encoder in this package cannot emit DRI, and no fixture in testdata/ uses
+// restart intervals, which is why this whole code path had no coverage.
+//
+// Huffman table: symbol 0 (difference category 0) = "0", symbol 1 (category 1)
+// = "10". Row 0 codes four zero differences; with the lossless predictor seeded
+// at 2^(P-1) that yields 128,128,128,128. Row 1 codes +1 then three zeros,
+// yielding 129,129,129,129 — chosen so a decoder that fails to consume the RST
+// marker (and therefore reads zero bits forever) produces 128s and is caught.
+func buildLosslessWithRestarts() []byte {
+	var b bytes.Buffer
+	b.Write([]byte{0xFF, 0xD8}) // SOI
+
+	// DRI: restart interval = 4 MCUs (one row)
+	b.Write([]byte{0xFF, 0xDD, 0x00, 0x04, 0x00, 0x04})
+
+	// SOF3: precision 8, height 2, width 4, 1 component (id 1, sampling 0x11, Tq 0)
+	b.Write([]byte{0xFF, 0xC3, 0x00, 0x0B, 0x08, 0x00, 0x02, 0x00, 0x04, 0x01, 0x01, 0x11, 0x00})
+
+	// DHT (class 0, table 0): one 1-bit code and one 2-bit code; symbols 0 and 1.
+	b.Write([]byte{0xFF, 0xC4, 0x00, 0x15, 0x00})
+	b.Write([]byte{0x01, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}) // counts, lengths 1..16
+	b.Write([]byte{0x00, 0x01})                                          // symbols
+
+	// SOS: 1 component (Cs 1, Td/Ta 0), Ss = predictor 1, Se 0, Ah/Al 0
+	b.Write([]byte{0xFF, 0xDA, 0x00, 0x08, 0x01, 0x01, 0x00, 0x01, 0x00, 0x00})
+
+	// Row 0: four zero differences -> "0000", padded to a byte with 1s.
+	b.WriteByte(0x0F)
+	// RST0 terminates the first restart interval.
+	b.Write([]byte{0xFF, 0xD0})
+	// Row 1: +1 then three zeros -> "10" "1" "000" = "101000", padded with 1s.
+	b.WriteByte(0xA3)
+
+	b.Write([]byte{0xFF, 0xD9}) // EOI
+	return b.Bytes()
+}
+
+// TestLosslessRestartMarkerIsConsumed is a regression test for silent pixel
+// corruption on conforming files. restart() previously consumed the RSTn marker
+// only when a prior fill() had already latched it; at a real interval boundary
+// the accumulator still held bits, so the marker was never consumed. The next
+// fill() then latched it and returned false forever, and every interval after
+// the first decoded as padding zeros — with no error returned.
+func TestLosslessRestartMarkerIsConsumed(t *testing.T) {
+	encoded := buildLosslessWithRestarts()
+	out := make([]byte, 4*2) // 4x2, 8-bit, 1 component
+
+	if err := decodeLosslessInto(encoded, out); err != nil {
+		t.Fatalf("decodeLosslessInto: %v", err)
+	}
+
+	want := []byte{128, 128, 128, 128, 129, 129, 129, 129}
+	if !bytes.Equal(out, want) {
+		t.Fatalf("restart interval decoded incorrectly:\n got %v\nwant %v\n"+
+			"(all-128 second row means the RST marker was not consumed)", out, want)
+	}
+}


### PR DESCRIPTION
## ⚠️ Silent pixel corruption on conforming files

`restart()` consumed the restart marker **only when a previous `fill()` had already latched it**. At a real interval boundary the bit accumulator still held buffered bits, so no `fill()` had looked at the marker yet and `br.pos` still sat on it. The marker was therefore never consumed: the next `fill()` latched it and returned `false`, and from then on `readBit` returned 0 forever.

**Every restart interval after the first decoded as padding zeros, and the decoder returned `nil`.**

This is not an attack case. Restart intervals are ordinary DICOM output from real modalities — this corrupts diagnostic pixels from **valid files**, silently, which is the worst failure mode for medical imaging.

## Reproduced

Hand-built 4×2 lossless stream with `DRI=4` (one RST between the two rows):

```
without the fix:  [128 128 128 128 | 128 128 128 128]   err = nil
with the fix:     [128 128 128 128 | 129 129 129 129]
```

The test fails without the fix and passes with it.

## Fix

`restart()` now also handles the not-yet-latched case: it scans forward for the RSTn, skipping the encoder's pad bits (T.81 E.1.1 requires padding to a byte boundary before the marker) and any stuffed `0xFF00`. A marker that is *not* an RSTn ends the scan and is left for the caller's normal marker handling.

The `bitReader` is shared with the DCT decoder (`gojpeg_dct.go:334` calls the same `restart()`), so that path is fixed by the same change.

## Why this survived

There was **no DRI/restart coverage anywhere** in `codecs/jpeg` or `codecs/jpegls` — no test, and no fixture in `testdata/` using restart intervals. The encoder in this package cannot emit DRI, so the test builds the stream by hand from SOI/DRI/SOF3/DHT/SOS with an explicit Huffman table, chosen so that a decoder which reads zero bits forever produces a visibly different result.

## Testing
- Regression test that fails without the fix (verified by stashing it)
- Full suite green; `go vet` clean
- **30M fuzz executions** on the lossless decoder after the change
- All three consumers build: io-scp, io-router, go-bridge

## Related, not in this PR

The same audit found other issues in these packages, deliberately left out to keep this reviewable: a brotli infinite loop (hard hang, reachable from any JPEG XL instance with a `jbrd` box), a brotli decompression bomb (809 B → 976 MiB, same class as #35), a 49-byte JPEG header causing a 2 GiB allocation before the output-size check, and silent success on truncated entropy data across all three JPEG-family decoders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)