### PR TITLE
fix(network): reject out-of-sequence A-ASSOCIATE PDUs (remote process crash)

### DIFF
--- a/network/pdu_service.go
+++ b/network/pdu_service.go
@@ -128,6 +128,13 @@ type pduService struct {
 	implClassUID                 string
 	implVersion                  string
 	logger                       *slog.Logger
+	// negotiated records that an association has been established on this
+	// connection. PS3.8 §9.3.1 permits exactly one A-ASSOCIATE-RQ per
+	// association; without this guard the same connection can renegotiate
+	// repeatedly, which both accumulates presentation-context state without
+	// bound and makes NextPDU return (nil, nil) at a point where the caller is
+	// reading a command's dataset and will dereference the result.
+	negotiated bool
 	// hdrScratch backs the 10-byte PDU header read. It cannot be a local in
 	// readIncomingPDU: passing a local's slice to io.ReadFull's io.Reader
 	// interface makes escape analysis heap-allocate it, which cost one
@@ -403,6 +410,9 @@ func (pdu *pduService) finishConnect(conn net.Conn) error {
 		if !pdu.interogateAAssociateAC() {
 			return errors.New("pduservice::Connect - No accepted presentation contexts found")
 		}
+		// The SCU side is now established; any later A-ASSOCIATE PDU on this
+		// connection is out of sequence (see NextPDU).
+		pdu.negotiated = true
 		maxSendPDV := pdu.AssocAC.GetMaxSubLength()
 		if maxSendPDV == 0 || maxSendPDV > maxPduLength {
 			maxSendPDV = maxPduLength
@@ -527,6 +537,14 @@ func (pdu *pduService) NextPDU() (command media.DICOMObject, err error) {
 
 		switch int(itemType) {
 		case pdutype.AssociationRequest:
+			if pdu.negotiated {
+				// PS3.8 §9.3.1 allows one A-ASSOCIATE-RQ per association; state
+				// AA-8 requires A-ABORT for a PDU received out of sequence.
+				// Returning an error here (rather than falling through to the
+				// (nil, nil) below) is what stops a caller reading a command's
+				// dataset from dereferencing a nil object.
+				return nil, pdu.abortWithError("unexpected A-ASSOCIATE-RQ on an established association")
+			}
 			pdu.buf.SetPosition(6)
 			if err := pdu.AssocRQ.Read(pdu.buf); err != nil {
 				return nil, err
@@ -539,10 +557,17 @@ func (pdu *pduService) NextPDU() (command media.DICOMObject, err error) {
 				}
 				return nil, err
 			}
+			pdu.negotiated = true
+			// The one legitimate (nil, nil): the association is now established
+			// and this PDU carried no data object. Callers reading a dataset must
+			// never reach this point — the guard above ensures they do not.
 			return nil, nil
 		case pdutype.AssociationAccept:
+			// An A-ASSOCIATE-AC is only valid while Connect is negotiating, and
+			// finishConnect consumes it there. Reaching NextPDU means the peer
+			// sent it out of sequence.
 			pdu.emitRawPDU(RawPDUDirectionInbound, itemType, rawData)
-			return nil, nil
+			return nil, pdu.abortWithError("unexpected A-ASSOCIATE-AC")
 		case pdutype.PDUDataTransfer:
 			pdu.emitRawPDU(RawPDUDirectionInbound, itemType, rawData)
 			pdu.buf.SetPosition(1)
@@ -585,6 +610,21 @@ func (pdu *pduService) NextPDU() (command media.DICOMObject, err error) {
 			return nil, errors.New("pduservice::Read - unknown ItemType")
 		}
 	}
+}
+
+// abortWithError sends an A-ABORT for a PDU received out of sequence and
+// returns the error to report. Used for protocol violations that PS3.8 §9.3.1
+// (state AA-8) requires be aborted rather than processed.
+//
+// NextPDU must never return (nil, nil) to a caller that is reading a dataset:
+// every such caller dereferences the returned object, and a nil dereference in
+// the per-connection goroutine terminates the process.
+func (pdu *pduService) abortWithError(reason string) error {
+	pdu.logger.Warn("aborting association: protocol violation", "reason", reason)
+	_ = pdu.writeEncodedPDU(byte(pdutype.AssociationAbortRequest), func(rw *bufio.ReadWriter) error {
+		return pdu.AbortRQ.Write(rw)
+	})
+	return fmt.Errorf("pduservice: %s", reason)
 }
 
 func (pdu *pduService) GetAAssociationRQ() AssociationRequest {

--- a/network/pdu_service_state_test.go
+++ b/network/pdu_service_state_test.go
@@ -1,0 +1,69 @@
+package network
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/network/internal/pdutype"
+)
+
+// TestNextPDUNeverReturnsNilNil is the core contract behind a remote crash.
+//
+// NextPDU returns (nil, nil) exactly once, to signal "association established,
+// no data object". Every other path must return a non-nil error, because the
+// callers that read a command's dataset dereference the returned object
+// immediately (services/scp_association.go does ddo.GetString(...) with no nil
+// check, and passes ddo to user-supplied store handlers). A nil dereference in
+// the per-connection goroutine has no recover() above it, so it terminates the
+// whole process — every in-flight association and the listener.
+//
+// The attack was: negotiate, send a command flagged dataset-present, then send
+// an A-ASSOCIATE-RQ instead of the dataset. Without a state guard that RQ was
+// renegotiated and NextPDU returned (nil, nil) straight into the dataset read.
+func TestNextPDUNeverReturnsNilNil(t *testing.T) {
+	cases := []struct {
+		name     string
+		itemType byte
+	}{
+		{"second A-ASSOCIATE-RQ on an established association", pdutype.AssociationRequest},
+		{"A-ASSOCIATE-AC out of sequence", pdutype.AssociationAccept},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// A 10-byte PDU carrying no body: enough for the dispatch to run.
+			pdu := pduWithReader(pduHeader(tc.itemType, 4))
+			// Simulate an association that has already been negotiated, which is
+			// the state the attack relies on.
+			pdu.negotiated = true
+
+			obj, err := pdu.NextPDU()
+			if err == nil {
+				t.Fatalf("expected an error, got obj=%v err=nil — a caller reading a "+
+					"dataset would dereference this and crash the process", obj)
+			}
+			if obj != nil {
+				t.Fatalf("expected a nil object alongside the error, got %v", obj)
+			}
+			if !strings.Contains(err.Error(), "unexpected A-ASSOCIATE") {
+				t.Fatalf("expected a protocol-violation error, got %v", err)
+			}
+		})
+	}
+}
+
+// TestFirstAssociationRequestStillNegotiates guards the fix from over-reaching:
+// the first A-ASSOCIATE-RQ must still be processed normally. A truncated RQ is
+// used here, so negotiation fails with a parse error rather than (nil, nil) —
+// the point is that it is NOT rejected by the state guard.
+func TestFirstAssociationRequestStillNegotiates(t *testing.T) {
+	pdu := pduWithReader(pduHeader(pdutype.AssociationRequest, 4))
+	if pdu.negotiated {
+		t.Fatal("a fresh pduService must not start out negotiated")
+	}
+
+	_, err := pdu.NextPDU()
+	if err != nil && strings.Contains(err.Error(), "unexpected A-ASSOCIATE-RQ") {
+		t.Fatalf("the first A-ASSOCIATE-RQ must not be rejected by the state guard: %v", err)
+	}
+}


### PR DESCRIPTION
## 🔴 Remote unauthenticated process crash

`NextPDU` returned `(nil, nil)` for A-ASSOCIATE-RQ and A-ASSOCIATE-AC. That is the intended signal for exactly one case — *"association established, this PDU carried no data object"* — but **nothing tracked whether an association was already established**, so it could be produced at any point.

Callers reading a command's dataset dereference the result immediately: `services/scp_association.go` does `ddo.GetString(...)` with **no nil check** after C-FIND/C-GET/C-MOVE, and hands `ddo` to user-supplied C-STORE handlers. The per-connection goroutine in `scp_server.go` has **no `recover()`**, so a nil dereference terminates the process — every in-flight association and the listener.

### Attack

1. Negotiate normally
2. Send a C-FIND-RQ command flagged `CommandDataSetType=DataSetPresent`
3. Send a 10-byte A-ASSOCIATE-AC (or a second A-ASSOCIATE-RQ) **instead of the dataset**

One TCP connection, **~250 bytes, no authentication.**

## Fix

Track association state and reject both PDUs once negotiated, per PS3.8 §9.3.1 (one A-ASSOCIATE-RQ per association) and state AA-8 (A-ABORT on a PDU received out of sequence). An A-ASSOCIATE-AC is never valid in `NextPDU` at all — `Connect` consumes it in `finishConnect` — so it is always rejected.

Rejecting the second A-ASSOCIATE-RQ **before** `AssocRQ.Read` also closes the presentation-context accumulation it fed: that path appended to `PresContexts` without ever resetting, so repeated RQs grew per-association state without bound (an audit measured 512 KiB of input → 8,197 MiB heap on a single association).

The one legitimate `(nil, nil)` is retained and documented; the guard is what keeps a dataset read from ever reaching it.

## Verification

The regression test asserts `NextPDU` never returns `(nil, nil)` for either PDU on an established association, and that a **first** A-ASSOCIATE-RQ is still negotiated normally (so the guard doesn't over-reach).

Proven by neutering only the guard — both cases then return exactly the crash condition:

```
expected an error, got obj=<nil> err=nil — a caller reading a dataset
would dereference this and crash the process
```

- Full suite green; `go vet` clean
- **All four network fuzz targets clean**: `FuzzAssociationRQRead`, `FuzzAssociationACReadDynamic`, `FuzzReadIncomingPDU`, `FuzzPDataTFReadDynamic`
- All three consumers build **and test** green: io-scp, io-router, go-bridge

## Related, deliberately not in this PR

A full ULM state machine (PS3.8 Table 9-10) would gate every PDU type by state rather than just the A-ASSOCIATE pair; this PR fixes the reachable crash without that refactor. Also still open from the same audit: no server-side read deadline (`SCP.SetTimeout` is a no-op on the accept path — slowloris), unbounded per-item UID allocation in `uid_item.go`/`role_select.go`, and no bound on total message size accumulated across P-DATA fragments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)