### PR TITLE
fix(network): bound UID item allocation from attacker-supplied lengths

### DIFF
--- a/network/role_select.go
+++ b/network/role_select.go
@@ -63,9 +63,12 @@ func (scpscu *roleSelect) ReadDynamic(buf *media.DICOMBuffer) (err error) {
 		return err
 	}
 
-	tuid := make([]byte, tl)
-	buf.ReadData(tuid)
-
+	// Bounds-checked, zero-copy read; see uid_item.go for why the previous
+	// allocate-then-ignore-the-error form was exploitable.
+	tuid, err := buf.ReadSlice(int(tl))
+	if err != nil {
+		return err
+	}
 	scpscu.uid = string(tuid)
 	if scpscu.SCURole, err = buf.GetByte(); err != nil {
 		return err

--- a/network/uid_item.go
+++ b/network/uid_item.go
@@ -100,9 +100,21 @@ func (u *uidItem) ReadDynamic(buf *media.DICOMBuffer) (err error) {
 		return err
 	}
 
-	buffer := make([]byte, u.length)
-	buf.ReadData(buffer)
-	u.uid = string(buffer)
+	// ReadSlice bounds-checks against the bytes actually present and returns a
+	// zero-copy view; string() then makes the single copy we keep.
+	//
+	// The previous form allocated make([]byte, u.length) BEFORE any bounds check
+	// and discarded ReadData's error. u.length is an attacker-controlled uint16,
+	// so a 4-byte item on the wire could declare 65535 bytes: the allocation
+	// happened anyway, the error was dropped, and the 64 KiB buffer was retained
+	// as the item's UID. A presentation-context item can pack thousands of such
+	// sub-items, which an audit measured at a 65,622-byte A-ASSOCIATE-RQ
+	// retaining 1,023 MiB.
+	data, err := buf.ReadSlice(int(u.length))
+	if err != nil {
+		return err
+	}
+	u.uid = string(data)
 
 	return
 }

--- a/network/uid_item_bounds_test.go
+++ b/network/uid_item_bounds_test.go
@@ -1,0 +1,89 @@
+package network
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/media"
+)
+
+// buildOverlongUIDItem encodes a UID sub-item whose declared length far exceeds
+// the bytes that follow it — the shape a hostile A-ASSOCIATE-RQ uses to make the
+// parser allocate far more than it received.
+// The item type is consumed by Read, so ReadDynamic starts at reserved1.
+func buildOverlongUIDItem(declared uint16, actual int) []byte {
+	out := []byte{
+		0x00,                                // reserved1
+		byte(declared >> 8), byte(declared), // declared length, big-endian
+	}
+	return append(out, make([]byte, actual)...)
+}
+
+// TestUIDItemRejectsOverlongLength pins the bounds check. The parser previously
+// did make([]byte, u.length) before any bounds check and discarded ReadData's
+// error, so a 4-byte item declaring 65535 bytes still allocated 64 KiB and
+// retained it as the item's UID.
+func TestUIDItemRejectsOverlongLength(t *testing.T) {
+	// 4 header bytes, no payload, declaring the maximum a uint16 can hold.
+	data := buildOverlongUIDItem(0xFFFF, 0)
+	buf := media.NewDICOMBufferFromBytes(data)
+
+	var u uidItem
+	if err := u.ReadDynamic(buf); err == nil {
+		t.Fatalf("expected an error for a declared length beyond the input, got uid of %d bytes", len(u.uid))
+	}
+	if u.uid != "" {
+		t.Fatalf("no UID should be retained on failure, got %d bytes", len(u.uid))
+	}
+}
+
+// TestUIDItemAllocationIsBoundedByInput measures the amplification directly:
+// parsing many overlong items must not retain memory disproportionate to the
+// bytes received.
+func TestUIDItemAllocationIsBoundedByInput(t *testing.T) {
+	const items = 4000
+	// Each item is 4 bytes on the wire but declares 65535 bytes of UID.
+	var wire []byte
+	for i := 0; i < items; i++ {
+		wire = append(wire, buildOverlongUIDItem(0xFFFF, 0)...)
+	}
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	buf := media.NewDICOMBufferFromBytes(wire)
+	parsed := 0
+	for i := 0; i < items; i++ {
+		var u uidItem
+		if err := u.ReadDynamic(buf); err != nil {
+			break // expected: the first item already runs past the input
+		}
+		parsed++
+	}
+
+	runtime.ReadMemStats(&after)
+	allocated := after.TotalAlloc - before.TotalAlloc
+	t.Logf("%d bytes of input, %d items parsed, %d bytes allocated (%.1fx)",
+		len(wire), parsed, allocated, float64(allocated)/float64(len(wire)))
+
+	// Before the fix each item allocated 64 KiB regardless of input, so 4000
+	// items amplified ~16000x. A small multiple of the input is the contract.
+	if allocated > uint64(len(wire))*8 {
+		t.Fatalf("allocation %d is disproportionate to %d bytes of input", allocated, len(wire))
+	}
+}
+
+// TestUIDItemValidRoundTrip guards against the bounds work rejecting good input.
+func TestUIDItemValidRoundTrip(t *testing.T) {
+	const uid = "1.2.840.10008.1.1"
+	data := append(buildOverlongUIDItem(uint16(len(uid)), 0), []byte(uid)...)
+
+	var u uidItem
+	if err := u.ReadDynamic(media.NewDICOMBufferFromBytes(data)); err != nil {
+		t.Fatalf("valid UID item should parse: %v", err)
+	}
+	if u.uid != uid {
+		t.Fatalf("got %q, want %q", u.uid, uid)
+	}
+}


### PR DESCRIPTION
## 🔴 ~16,000× memory amplification, pre-authentication

`uidItem.ReadDynamic` and `roleSelect.ReadDynamic` both did:

```go
buffer := make([]byte, declaredLength)
buf.ReadData(buffer)          // error discarded
field = string(buffer)
```

The declared length is an **attacker-controlled uint16 read straight off the wire**, never checked against the bytes actually remaining. A 4-byte sub-item declaring 65535 bytes still allocated 64 KiB, the failing `ReadData` error was **dropped**, and the buffer was retained as the item's UID.

A presentation-context item is itself length-delimited by a uint16, so one can pack roughly **16,000 four-byte transfer-syntax sub-items**, and an association may carry many contexts. An audit measured a **65,622-byte A-ASSOCIATE-RQ retaining 1,023.8 MiB** — reachable from any peer that can open an association, before any authentication.

## Fix

Use `ReadSlice`, which bounds-checks against the bytes present and returns a zero-copy view; `string()` then makes the single copy that is kept.

That fixes all three defects at once:
- allocation is bounded by the **input**, not by what it declares
- the error is **propagated** instead of discarded
- the redundant intermediate buffer is gone (two allocations become one)

## Tests

Assert an overlong declared length is rejected with no UID retained, that a valid item still round-trips, and — measuring directly with `MemStats` — that parsing a wire full of overlong items allocates a small multiple of the input rather than a multiple of what it declares:

```
12000 bytes of input, 0 items parsed, 2872 bytes allocated (0.2x)
```

Full suite green, `go vet` clean, association fuzz targets clean, all three consumers build.

## Still open in this area

**No server-side read deadline.** `SCP.SetTimeout` is a no-op on the accept path — a peer that sends 3 bytes and stalls holds a goroutine and an association slot indefinitely (slowloris). I deliberately did **not** fix it here: `services.pollCommand` sets a short `cancelPoll` read deadline around `NextPDU` and clears it afterwards, so unconditionally applying a longer timeout inside `readIncomingPDU` would override it and **break C-CANCEL polling**. It needs a deliberate design decision about where the association-idle timeout lives, not a one-line change.

Also outstanding: no bound on total message size accumulated across P-DATA fragments (each PDU is capped at 16 MiB, the sum is not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)