### PR TITLE
fix(codecs): report truncated entropy data instead of returning padding

### DIFF
--- a/codecs/jpeg/gojpeg_dct.go
+++ b/codecs/jpeg/gojpeg_dct.go
@@ -364,6 +364,13 @@ func decodeDCTScan(entropy []byte, frame *dctFrame, quant *[4][64]int, dcTab, ac
 			mcuCount++
 		}
 	}
+	segments := 1
+	if frame.restartIv > 0 && mcuCount > 0 {
+		segments += mcuCount / frame.restartIv
+	}
+	if err := br.checkNotTruncated(segments); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/codecs/jpeg/gojpeg_lossless.go
+++ b/codecs/jpeg/gojpeg_lossless.go
@@ -19,6 +19,7 @@ var (
 	errGoJPEGMalformed   = errors.New("gojpeg: malformed JPEG payload")
 	errGoJPEGUnsupported = errors.New("gojpeg: unsupported JPEG variant (pure-Go decoder handles lossless SOF3 only)")
 	errGoJPEGOutputSize  = errors.New("gojpeg: decoded payload does not fit output buffer")
+	errGoJPEGTruncated   = errors.New("gojpeg: truncated entropy data")
 )
 
 const (
@@ -90,6 +91,14 @@ type bitReader struct {
 	nbits    uint
 	atMarker bool // a marker (other than stuffed 0x00) was reached
 	marker   byte
+	// padBits counts bits served from padding after the entropy-coded data ran
+	// out. A few are normal (each segment is bit-padded to a byte boundary), but
+	// a truncated stream reconstructs whole samples from zeros — which previously
+	// produced a fully populated output buffer and a nil error.
+	padBits int
+	// realBits counts bits actually served from the entropy-coded data, as
+	// opposed to manufactured padding.
+	realBits int
 }
 
 // fill loads one more byte into the bit accumulator. Returns false at a marker
@@ -117,11 +126,13 @@ func (br *bitReader) fill() bool {
 	}
 	br.bits |= uint32(b) << (24 - br.nbits)
 	br.nbits += 8
+	br.realBits += 8
 	return true
 }
 
 func (br *bitReader) readBit() int {
 	if br.nbits == 0 && !br.fill() {
+		br.padBits++
 		return 0
 	}
 	bit := int((br.bits >> 31) & 1)
@@ -212,6 +223,27 @@ func (br *bitReader) restart() {
 			return
 		}
 	}
+}
+
+// checkNotTruncated reports an error when more bits were manufactured from
+// padding than the format legitimately allows. T.81 pads each entropy-coded
+// segment to a byte boundary, so up to 7 bits per segment are expected; beyond
+// that the entropy data ended before the image did.
+func (br *bitReader) checkNotTruncated(segments int) error {
+	// A scan that served no real bits at all cannot have legitimate padding: the
+	// entropy data is absent entirely. Checking this separately matters because
+	// a segment-count-derived allowance alone let a tiny empty scan through, and
+	// it decoded to a full buffer of the predictor seed with no error.
+	if br.realBits == 0 && br.padBits > 0 {
+		return errGoJPEGTruncated
+	}
+	if segments < 1 {
+		segments = 1
+	}
+	if allowed := 7 * segments; br.padBits > allowed {
+		return errGoJPEGTruncated
+	}
+	return nil
 }
 
 // decodeLossless parses and decodes a lossless SOF3 JPEG, returning interleaved
@@ -460,6 +492,13 @@ func decodeScan(entropy []byte, frame *losslessFrame, huff *[4]*huffTable) ([]in
 			}
 			mcu++
 		}
+	}
+	segments := 1
+	if frame.restartIv > 0 {
+		segments += (w * h) / frame.restartIv
+	}
+	if err := br.checkNotTruncated(segments); err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/codecs/jpeg/truncation_test.go
+++ b/codecs/jpeg/truncation_test.go
@@ -1,0 +1,54 @@
+package jpeg
+
+import (
+	"testing"
+)
+
+// TestLosslessRejectsMissingEntropyData pins truncation detection on the
+// lossless decoder.
+//
+// The bit reader returns zeros once the entropy-coded data runs out, and
+// nothing reported that it had done so, so a stream whose scan carried no
+// entropy bytes at all decoded to a completely filled buffer of the predictor's
+// seed value and returned nil. In diagnostic imaging a plausible-looking wrong
+// image is worse than a failed decode.
+func TestLosslessRejectsMissingEntropyData(t *testing.T) {
+	// A conforming 4x2 8-bit lossless stream, but with every entropy byte after
+	// SOS removed (SOI, SOF3, DHT, SOS header, then straight to EOI).
+	stream := buildLosslessWithRestarts()
+
+	sos := -1
+	for i := 0; i+1 < len(stream); i++ {
+		if stream[i] == 0xFF && stream[i+1] == 0xDA {
+			sos = i
+			break
+		}
+	}
+	if sos < 0 {
+		t.Fatal("no SOS marker in the generated stream")
+	}
+	segLen := int(stream[sos+2])<<8 | int(stream[sos+3])
+	headerOnly := append([]byte{}, stream[:sos+2+segLen]...)
+	headerOnly = append(headerOnly, 0xFF, 0xD9) // EOI
+
+	out := make([]byte, 4*2)
+	if err := decodeLosslessInto(headerOnly, out); err == nil {
+		t.Fatalf("a scan with no entropy data decoded to %v with no error", out)
+	}
+}
+
+// TestLosslessIntactStreamStillDecodes guards the truncation check from
+// rejecting valid input — including the restart-interval case, where each
+// entropy segment is legitimately bit-padded and so contributes some padding.
+func TestLosslessIntactStreamStillDecodes(t *testing.T) {
+	out := make([]byte, 4*2)
+	if err := decodeLosslessInto(buildLosslessWithRestarts(), out); err != nil {
+		t.Fatalf("intact stream with restart intervals must decode: %v", err)
+	}
+	want := []byte{128, 128, 128, 128, 129, 129, 129, 129}
+	for i := range want {
+		if out[i] != want[i] {
+			t.Fatalf("decoded %v, want %v", out, want)
+		}
+	}
+}

--- a/codecs/jpegls/gojpegls.go
+++ b/codecs/jpegls/gojpegls.go
@@ -13,6 +13,7 @@ package jpegls
 
 import (
 	"errors"
+	"fmt"
 	"math/bits"
 )
 
@@ -69,6 +70,11 @@ type jlsBitReader struct {
 	acc       uint64 // valid bits live in the low nbits; next bit is bit (nbits-1)
 	nbits     int    // number of valid bits currently in acc (0..64)
 	lastWasFF bool   // the previously loaded byte was 0xFF
+	// padBits counts bits served from zero padding after the entropy-coded data
+	// ran out. Reading a few is normal (the final byte is bit-padded), but a
+	// truncated stream decodes whole samples from padding, which previously
+	// produced a full buffer of plausible pixels and a nil error.
+	padBits int
 }
 
 // fill loads bytes into acc until it holds at least 56 bits or the data is
@@ -92,7 +98,8 @@ func (br *jlsBitReader) readBit() int {
 	if br.nbits == 0 {
 		br.fill()
 		if br.nbits == 0 {
-			return 0 // pad with zeros past EOF
+			br.padBits++ // served from padding: the entropy data ran out
+			return 0
 		}
 	}
 	br.nbits--
@@ -108,6 +115,7 @@ func (br *jlsBitReader) readBits(n int) int {
 		br.fill()
 		if br.nbits == before {
 			// EOF: take what remains, pad the rest with zero bits (MSB-first).
+			br.padBits += n - br.nbits
 			v := int(br.acc&mask(br.nbits)) << (n - br.nbits)
 			br.nbits = 0
 			return v
@@ -127,7 +135,12 @@ func (br *jlsBitReader) readZeros(cap int) int {
 		if br.nbits == 0 {
 			br.fill()
 			if br.nbits == 0 {
-				return cap // past EOF: treat as an over-long (capped) run
+				// Past EOF: an entire capped run is manufactured from nothing.
+				// This is the dominant reader in Golomb run-mode decoding, so
+				// without recording it here a truncated stream showed only a
+				// handful of padded bits while most of the image was invented.
+				br.padBits += cap
+				return cap
 			}
 		}
 		// Left-align the nbits valid bits so the first unread bit is bit 63.
@@ -409,4 +422,22 @@ func predict(a, b, c int) int {
 		return max(a, b)
 	}
 	return a + b - c
+}
+
+// checkNotTruncated reports an error when the decoder had to manufacture a
+// meaningful number of bits from padding, which means the entropy-coded data
+// ended before the image did.
+//
+// A JPEG-LS scan is bit-padded to a byte boundary, so up to 7 padded bits are
+// legitimate at the end of the stream. Anything beyond that means whole samples
+// were reconstructed from zeros. Without this check a truncated stream returned
+// a completely filled output buffer and a nil error: an audit measured a 50%
+// truncation yielding 47.9% wrong pixels, and a header-only 25-byte stream
+// yielding a full buffer of 0xFFFF, both reported as success.
+func (br *jlsBitReader) checkNotTruncated() error {
+	const allowedPadBits = 7
+	if br.padBits > allowedPadBits {
+		return fmt.Errorf("gojpegls: truncated entropy data (%d bits read past end of stream)", br.padBits)
+	}
+	return nil
 }

--- a/codecs/jpegls/gojpegls_scan.go
+++ b/codecs/jpegls/gojpegls_scan.go
@@ -178,7 +178,7 @@ func decodeJLSInto(encoded, output []byte) error {
 			d.decodePlaneInto(output, c, nc, bps)
 		}
 	}
-	return nil
+	return d.br.checkNotTruncated()
 }
 
 // decodeScalarLine decodes one scan line of a single component into cur, using

--- a/codecs/jpegls/truncation_test.go
+++ b/codecs/jpegls/truncation_test.go
@@ -1,0 +1,78 @@
+package jpegls
+
+import (
+	"testing"
+)
+
+// encodeSynth returns a real JPEG-LS stream for a w*h 16-bit grayscale frame,
+// plus the raw pixels it encodes.
+func encodeSynth(t *testing.T, w, h int) (stream []byte, raw []byte) {
+	t.Helper()
+	raw = synthFrame(w, h)
+	var out []byte
+	var size int
+	if err := JLSencode(raw, uint16(w), uint16(h), 1, 16, &out, &size, false); err != nil {
+		t.Skipf("JLSencode unavailable: %v", err)
+	}
+	return out[:size], raw
+}
+
+// TestDecodeRejectsTruncatedStream pins truncation detection.
+//
+// The bit reader pads with zeros past the end of the entropy-coded data, and no
+// decode function reported that it had done so, so a truncated stream produced a
+// completely filled output buffer and a nil error. An audit measured a stream cut
+// to 50% yielding 47.9% wrong pixels — reported as success. In diagnostic imaging
+// a plausible-looking wrong image is worse than a failed decode.
+func TestDecodeRejectsTruncatedStream(t *testing.T) {
+	const w, h = 64, 64
+	stream, raw := encodeSynth(t, w, h)
+
+	// Sanity: the intact stream still decodes correctly.
+	full := make([]byte, len(raw))
+	if err := JLSdecode(stream, uint32(len(stream)), full); err != nil {
+		t.Fatalf("intact stream must decode: %v", err)
+	}
+
+	for _, pct := range []int{10, 50, 90} {
+		cut := len(stream) * pct / 100
+		out := make([]byte, len(raw))
+		err := JLSdecode(stream[:cut], uint32(cut), out)
+		if err == nil {
+			t.Errorf("stream truncated to %d%% (%d of %d bytes) decoded with no error",
+				pct, cut, len(stream))
+		}
+	}
+}
+
+// TestDecodeRejectsHeaderOnlyStream covers the degenerate case: a stream with a
+// complete header and no entropy data at all previously filled the whole buffer
+// with a constant and returned nil.
+func TestDecodeRejectsHeaderOnlyStream(t *testing.T) {
+	const w, h = 64, 64
+	stream, raw := encodeSynth(t, w, h)
+
+	// Find the SOS marker (0xFFDA) and keep only its header, dropping every
+	// entropy byte that follows.
+	sos := -1
+	for i := 0; i+1 < len(stream); i++ {
+		if stream[i] == 0xFF && stream[i+1] == 0xDA {
+			sos = i
+			break
+		}
+	}
+	if sos < 0 {
+		t.Skip("no SOS marker found in the encoded stream")
+	}
+	if sos+4 > len(stream) {
+		t.Skip("stream too short to isolate the SOS header")
+	}
+	segLen := int(stream[sos+2])<<8 | int(stream[sos+3])
+	headerOnly := stream[:sos+2+segLen]
+
+	out := make([]byte, len(raw))
+	if err := JLSdecode(headerOnly, uint32(len(headerOnly)), out); err == nil {
+		t.Fatalf("a %d-byte header-only stream decoded %d bytes with no error",
+			len(headerOnly), len(out))
+	}
+}


### PR DESCRIPTION
## ⚠️ Silent wrong pixels from truncated streams

All three JPEG-family decoders pad with zeros once the entropy-coded data runs out, and **none reported having done so** — so a truncated stream produced a completely filled output buffer and a `nil` error. An audit measured:

| input | result | reported |
|---|---|---|
| JPEG-LS truncated to 90% / 50% / 10% | **7.1% / 47.9% / 88.2% wrong bytes** | success |
| JPEG-LS header-only, 25 bytes | full buffer of `0xFFFF` | success |
| JPEG lossless, zero entropy bytes | full buffer of `0x8000` | success |
| JPEG DCT, zero entropy bytes | full buffer of `0x0800` | success |

A plausible-looking wrong image is the worst failure mode for diagnostic data — nothing downstream can distinguish it from a good decode. This is the same class as the restart-marker bug in #37, by a different mechanism.

## Fix

Both readers now count bits served from padding, and the top-level decode checks that count. Each entropy-coded segment is legitimately bit-padded to a byte boundary, so 7 bits per segment are allowed; beyond that the data ended before the image did.

## Two things the tests caught that reading did not

**JPEG-LS: `readZeros` has its own EOF path.** Counting only `readBit`/`readBits` showed just **3–7 padded bits even at 10% truncation** — because Golomb run-mode decoding manufactures whole runs through `readZeros`, which returns a capped run and was not recorded. It now records the run it invents.

**JPEG: a segment-count allowance alone was too generous for small images.** An empty 4×2 scan needed 8 padded bits against an allowance of 21 (7 × 3 segments) and slipped straight through. The reader now also tracks bits served from *real* data, and a scan that served none cannot have legitimate padding.

Both were found by a failing test, not by inspection — worth noting because the first version of this fix looked correct and did nothing.

## Intact streams unaffected

Including the restart-interval case, where every segment legitimately contributes padding. The existing round-trip, golden and representative-matrix tests pass unchanged.

## Testing
- New truncation tests for both packages: 10/50/90% truncation and header-only cases must error; intact streams must still decode to the exact expected pixels
- Full suite green; `go vet` clean
- `FuzzGoJPEGLossless`, `FuzzGoJPEGDCT`, `FuzzGoJLS` all clean after the change
- All three consumers build and test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)