### PR TITLE
fix(jpeg): enforce the output-size bound before sizing buffers from the header

### DIFF
--- a/codecs/jpeg/alloc_bounds_test.go
+++ b/codecs/jpeg/alloc_bounds_test.go
@@ -1,0 +1,82 @@
+package jpeg
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+// buildSOFOnly returns a tiny JPEG carrying only SOI + a frame header declaring
+// huge dimensions, with no entropy data. The decoder must reject it on the
+// header alone rather than sizing buffers from those dimensions.
+func buildSOFOnly(sofMarker byte, w, h uint16, precision byte) []byte {
+	out := []byte{0xFF, 0xD8} // SOI
+	// SOF: len(11), precision, height, width, 1 component (id 1, sampling 0x11, Tq 0)
+	out = append(out, 0xFF, sofMarker, 0x00, 0x0B, precision,
+		byte(h>>8), byte(h), byte(w>>8), byte(w), 0x01, 0x01, 0x11, 0x00)
+	out = append(out, 0xFF, 0xD9) // EOI
+	return out
+}
+
+// TestHeaderDeclaringHugeDimensionsIsRejectedCheaply pins the ordering fix.
+//
+// decodeLossless/decodeDCT sized their sample buffers from the SOF dimensions
+// and ran the whole scan; the output-size check lived in the *Into wrappers,
+// i.e. after the fact. A 49-byte header declaring 16384x16384 therefore
+// allocated 2 GiB and spent ~1.8s before reporting a size mismatch — about
+// 44,000,000:1 amplification, multiplied by the worker count under concurrent
+// frame decoding.
+func TestHeaderDeclaringHugeDimensionsIsRejectedCheaply(t *testing.T) {
+	cases := []struct {
+		name   string
+		stream []byte
+		decode func([]byte, []byte) error
+	}{
+		{"lossless 16384x16384 16-bit", buildSOFOnly(mSOF3, 16384, 16384, 16), decodeLosslessInto},
+		{"lossless 8192x8192 8-bit", buildSOFOnly(mSOF3, 8192, 8192, 8), decodeLosslessInto},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := make([]byte, 1) // deliberately far too small
+
+			var before, after runtime.MemStats
+			runtime.GC()
+			runtime.ReadMemStats(&before)
+			start := time.Now()
+
+			err := tc.decode(tc.stream, out)
+
+			elapsed := time.Since(start)
+			runtime.ReadMemStats(&after)
+			allocated := after.TotalAlloc - before.TotalAlloc
+
+			t.Logf("%d-byte header -> %d bytes allocated in %v", len(tc.stream), allocated, elapsed)
+
+			if err == nil {
+				t.Fatal("expected an output-size error")
+			}
+			// The rejection must be on the header alone. A few KiB of parsing
+			// overhead is fine; megabytes means buffers were sized from the
+			// declared dimensions.
+			if allocated > 1<<20 {
+				t.Fatalf("rejecting a %d-byte header allocated %d bytes; the size check "+
+					"is still running after the buffers are sized", len(tc.stream), allocated)
+			}
+		})
+	}
+}
+
+// TestValidStreamStillDecodesUnderBound guards the ordering change from
+// rejecting legitimate input whose output fits exactly.
+func TestValidStreamStillDecodesUnderBound(t *testing.T) {
+	stream := buildLosslessWithRestarts() // 4x2, 8-bit, 1 component
+	out := make([]byte, 4*2)
+	if err := decodeLosslessInto(stream, out); err != nil {
+		t.Fatalf("a stream whose output fits exactly must decode: %v", err)
+	}
+	// One byte short must still be rejected.
+	if err := decodeLosslessInto(stream, make([]byte, 4*2-1)); err == nil {
+		t.Fatal("expected an output-size error when the buffer is one byte short")
+	}
+}

--- a/codecs/jpeg/gojpeg_dct.go
+++ b/codecs/jpeg/gojpeg_dct.go
@@ -95,6 +95,15 @@ func idct8x8(block *[64]float64) {
 
 // decodeDCT parses and decodes a SOF0/SOF1 JPEG into per-component planes.
 func decodeDCT(data []byte) (dctFrame, error) {
+	return decodeDCTBounded(data, -1)
+}
+
+// decodeDCTBounded is decodeDCT with an optional ceiling on the decoded byte
+// size, enforced as soon as the SOF header is parsed rather than after the scan.
+// It also rejects the unsupported multi-component case there: that rejection
+// previously happened after a full decode, burning 96 MiB and ~90ms on a
+// 3-component 2048x2048 stream before returning "unsupported".
+func decodeDCTBounded(data []byte, maxOutputBytes int) (dctFrame, error) {
 	var frame dctFrame
 	if len(data) < 2 || data[0] != 0xFF || data[1] != mSOI {
 		return frame, errGoJPEGMalformed
@@ -132,6 +141,22 @@ func decodeDCT(data []byte) (dctFrame, error) {
 		case mSOF0, mSOF1:
 			if err := parseSOFDCT(seg, &frame); err != nil {
 				return frame, err
+			}
+			if len(frame.comps) != 1 {
+				// Multi-component DCT is deferred to libjpeg; reject before
+				// allocating rather than after decoding.
+				return frame, errGoJPEGUnsupported
+			}
+			if maxOutputBytes >= 0 {
+				bps := 1
+				if frame.precision > 8 {
+					bps = 2
+				}
+				// int64 so the product cannot wrap on 32-bit builds.
+				if need := int64(frame.width) * int64(frame.height) *
+					int64(len(frame.comps)) * int64(bps); need > int64(maxOutputBytes) {
+					return frame, errGoJPEGOutputSize
+				}
 			}
 			sawSOF = true
 		case mDHT:
@@ -468,7 +493,7 @@ func gojpegDecodeInto(encoded, output []byte) error {
 // decodeDCTInto decodes a DCT JPEG and packs grayscale/RGB samples into output
 // using the codec's little-endian convention (2 bytes/sample at 12-bit).
 func decodeDCTInto(encoded, output []byte) error {
-	frame, err := decodeDCT(encoded)
+	frame, err := decodeDCTBounded(encoded, len(output))
 	if err != nil {
 		return err
 	}

--- a/codecs/jpeg/gojpeg_lossless.go
+++ b/codecs/jpeg/gojpeg_lossless.go
@@ -249,6 +249,18 @@ func (br *bitReader) checkNotTruncated(segments int) error {
 // decodeLossless parses and decodes a lossless SOF3 JPEG, returning interleaved
 // samples (one int per component per pixel, component-minor) plus geometry.
 func decodeLossless(data []byte) (frame losslessFrame, samples []int, err error) {
+	return decodeLosslessBounded(data, -1)
+}
+
+// decodeLosslessBounded is decodeLossless with an optional ceiling on the
+// decoded byte size. Pass -1 for no ceiling.
+//
+// The bound is enforced as soon as the SOF header is parsed, before any buffer
+// is sized from it. Checking only after the scan meant a 49-byte header
+// declaring 16384x16384 allocated 2 GiB and spent ~1.8s decoding before the
+// output-size mismatch was noticed -- roughly 44,000,000:1 amplification,
+// multiplied by the worker count under concurrent frame decoding.
+func decodeLosslessBounded(data []byte, maxOutputBytes int) (frame losslessFrame, samples []int, err error) {
 	if len(data) < 2 || data[0] != 0xFF || data[1] != mSOI {
 		return frame, nil, errGoJPEGMalformed
 	}
@@ -283,6 +295,17 @@ func decodeLossless(data []byte) (frame losslessFrame, samples []int, err error)
 		case mSOF3:
 			if err := parseSOF3(seg, &frame); err != nil {
 				return frame, nil, err
+			}
+			if maxOutputBytes >= 0 {
+				bps := 1
+				if frame.precision > 8 {
+					bps = 2
+				}
+				// int64 so the product cannot wrap on 32-bit builds.
+				if need := int64(frame.width) * int64(frame.height) *
+					int64(len(frame.comps)) * int64(bps); need > int64(maxOutputBytes) {
+					return frame, nil, errGoJPEGOutputSize
+				}
 			}
 			sawSOF = true
 		case mDHT:
@@ -526,7 +549,7 @@ func predict(sel, ra, rb, rc int) int {
 // decodeLosslessInto decodes a lossless JPEG and packs it into output using the
 // codec's little-endian convention: 1 byte/sample when precision <= 8, else 2.
 func decodeLosslessInto(encoded, output []byte) error {
-	frame, samples, err := decodeLossless(encoded)
+	frame, samples, err := decodeLosslessBounded(encoded, len(output))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 🔴 ~44,000,000:1 memory amplification from a tiny header

`decodeLossless` and `decodeDCT` sized their sample buffers straight from the SOF dimensions and ran the **entire scan**; the output-size check lived in the `*Into` wrappers — i.e. after the fact. A tiny header therefore bought an arbitrarily large allocation:

| stream | input | allocated | time |
|---|---|---|---|
| lossless 2048×2048 16-bit | 49 B | 32 MiB | 36 ms |
| lossless 8192×8192 | 49 B | 512 MiB | 471 ms |
| lossless 16384×16384 | 49 B | **2048 MiB** | **1.82 s** |
| DCT 16384×16384 12-bit | 140 B | **2048 MiB** | **1.97 s** |

Reachable from any received instance, and multiplied by the worker count under concurrent frame decoding.

## Fix

`decodeLosslessBounded` / `decodeDCTBounded` take the caller's output size and enforce it **as soon as the SOF header is parsed** — before any buffer is sized from those dimensions. The existing one-argument entry points remain for tests and pass `-1` for "no ceiling". The product is computed in `int64` so it cannot wrap on 32-bit builds.

Also moves the DCT decoder's **multi-component rejection** to the same point. It previously ran after a full decode, so a 3-component 2048×2048 stream burned **96 MiB and ~90 ms** before returning "unsupported".

## Measured after the change

```
17-byte header declaring 16384x16384 -> 16 bytes allocated in 27µs
```

The test asserts the rejection allocates under 1 MiB, so a regression that moves the check back after the buffers are sized fails immediately. A second test pins that a stream whose output fits exactly still decodes, and that one byte short is still rejected.

## Testing
- Full suite green; `go vet` clean
- `FuzzGoJPEGLossless` and `FuzzGoJPEGDCT` clean after the change
- All three consumers build: io-scp, io-router, go-bridge

## Related, not in this PR

The audit's larger finding here is that the `[]int` sample plane is 8 bytes/sample for ≤16-bit data and is 100% of the decoder's allocation (134 MB/op at 4096²). Streaming directly into `output` — the pattern `codecs/jpegls`'s `decodePlaneInto` already uses — measured **134,218,208 → 33,248 B/op**, roughly 4000×, at unchanged wall-clock. That is a decoder rewrite rather than an ordering fix, so it belongs in its own change; this PR closes the DoS surface it would also have closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)