### PR TITLE
fix(wado): validate UIDs, bound STOW uploads, report stores that failed

### DIFF
--- a/wado/client.go
+++ b/wado/client.go
@@ -141,6 +141,13 @@ func (c *wadoClient) RetrieveMetadata(ctx context.Context, studyUID, seriesUID, 
 // ── STOW-RS store ─────────────────────────────────────────────────────────────
 
 func (c *wadoClient) StoreInstances(ctx context.Context, studyUID string, objects []media.DICOMObject) error {
+	// Nothing to send: return without a request rather than POSTing an empty
+	// multipart body. A STOW-RS request that stores no instances is a failure
+	// per PS3.18 §10.5, so sending one to mean "no work" would now be rejected.
+	if len(objects) == 0 {
+		return nil
+	}
+
 	// Stream the multipart body through a pipe to avoid buffering all objects
 	// in memory at once.
 	pr, pw := io.Pipe()

--- a/wado/security_test.go
+++ b/wado/security_test.go
@@ -1,0 +1,144 @@
+package wado_test
+
+import (
+	"bytes"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/textproto"
+	"strings"
+	"testing"
+)
+
+// TestPathTraversalUIDsRejected pins UID validation on every path handler.
+//
+// Go's ServeMux percent-decodes path wildcards, so `..%2f..%2f` reaches the
+// handler as the literal `../../` and `a%00b` arrives with an embedded NUL.
+// Those previously went to the Store verbatim. io-scp's Store resolves UIDs
+// through a query engine and is unaffected, but the Store interface documents no
+// validation obligation and the canonical DICOM layout is
+// {studyUID}/{seriesUID}/{sopUID}.dcm — a filesystem- or object-store-backed
+// implementation would inherit an arbitrary read/delete primitive.
+func TestPathTraversalUIDsRejected(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	hostile := []string{
+		"..%2f..%2f..%2fetc%2fpasswd",
+		"%2e%2e%2f%2e%2e%2fsecret",
+		"%2fabsolute%2fpath",
+		"a%00b",
+		"1.2.3%2f..%2f..%2fadmin",
+		strings.Repeat("1", 65), // over the 64-character UID limit
+		"not-a-uid",
+	}
+
+	for _, uid := range hostile {
+		for _, tmpl := range []struct{ method, path string }{
+			{"GET", "/wado/rs/studies/%s"},
+			{"GET", "/wado/rs/studies/%s/metadata"},
+			{"GET", "/wado/rs/studies/1.2.3/series/%s"},
+			{"DELETE", "/wado/rs/studies/%s"},
+			{"DELETE", "/wado/rs/studies/1.2.3/series/1.2.4/instances/%s"},
+		} {
+			path := fmt.Sprintf(tmpl.path, uid)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(tmpl.method, path, nil))
+			// Acceptable: 400 from validation, or a 3xx where ServeMux
+			// normalised the path away before routing. Anything else — notably
+			// 404 — means the hostile string reached the Store and was treated
+			// as a legitimate UID.
+			redirected := rec.Code >= 300 && rec.Code < 400
+			if rec.Code != http.StatusBadRequest && !redirected {
+				t.Errorf("%s %s: got %d; the UID reached the Store instead of being rejected",
+					tmpl.method, path, rec.Code)
+			}
+		}
+	}
+}
+
+// TestValidUIDsStillAccepted guards the validator from rejecting real UIDs.
+func TestValidUIDsStillAccepted(t *testing.T) {
+	h, _ := newTestHandler(t)
+	for _, uid := range []string{
+		"1.2.840.10008.1.1",
+		"1.2.840.113619.2.30.1.1762295590.1623.978668949.886",
+		"1",
+		strings.Repeat("1", 64), // exactly the 64-character limit
+	} {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest("GET", "/wado/rs/studies/"+uid, nil))
+		if rec.Code == http.StatusBadRequest {
+			t.Errorf("valid UID %q was rejected as malformed", uid)
+		}
+	}
+}
+
+// multipartBody builds a STOW-RS body from the supplied part payloads.
+func multipartBody(parts ...[]byte) (body []byte, contentType string) {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	for _, p := range parts {
+		w, _ := mw.CreatePart(textproto.MIMEHeader{
+			"Content-Type": []string{"application/dicom"},
+		})
+		_, _ = w.Write(p)
+	}
+	_ = mw.Close()
+	return buf.Bytes(), fmt.Sprintf(`multipart/related; type="application/dicom"; boundary=%s`, mw.Boundary())
+}
+
+// TestStoreReportsFailureWhenNothingStored is the data-loss guard.
+//
+// Every part that failed to read or parse was skipped with `continue`, and the
+// handler unconditionally wrote 200 with an empty ReferencedSOPSequence. A
+// sending modality that treats 200 as "safely archived" and deletes its local
+// copy would lose the study. PS3.18 §10.5 requires a failure status when no
+// instances are stored.
+func TestStoreReportsFailureWhenNothingStored(t *testing.T) {
+	h, store := newTestHandler(t)
+
+	cases := []struct {
+		name  string
+		parts [][]byte
+	}{
+		{"all parts unparseable", [][]byte{[]byte("not dicom"), []byte("also not dicom")}},
+		{"single garbage part", [][]byte{bytes.Repeat([]byte{0xFF}, 512)}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, ct := multipartBody(tc.parts...)
+			req := httptest.NewRequest("POST", "/stow/rs/studies", bytes.NewReader(body))
+			req.Header.Set("Content-Type", ct)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			// Nothing was stored, so the status must be a failure. 200 and 202
+			// both tell a client the upload was accepted; a modality that then
+			// deletes its local copy loses the study.
+			if rec.Code < 400 {
+				t.Fatalf("stored nothing but returned %d — a client would treat the "+
+					"study as archived (body: %s)", rec.Code, rec.Body.String())
+			}
+			if len(store.stored) != 0 {
+				t.Fatalf("expected nothing stored, got %d", len(store.stored))
+			}
+		})
+	}
+}
+
+// TestStoreRejectsEmptyBody covers the degenerate case: a well-formed multipart
+// carrying no parts previously returned 200 with an empty sequence.
+func TestStoreRejectsEmptyBody(t *testing.T) {
+	h, _ := newTestHandler(t)
+	body, ct := multipartBody()
+	req := httptest.NewRequest("POST", "/stow/rs/studies", bytes.NewReader(body))
+	req.Header.Set("Content-Type", ct)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code < 400 {
+		t.Fatalf("an empty upload returned %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/wado/server.go
+++ b/wado/server.go
@@ -3,6 +3,7 @@ package wado
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -11,6 +12,7 @@ import (
 	"net/http"
 	"net/textproto"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -166,6 +168,9 @@ func (s *wadoServer) buildMux() *http.ServeMux {
 // ── WADO-RS retrieve handlers ─────────────────────────────────────────────────
 
 func (s *wadoServer) retrieveStudy(w http.ResponseWriter, r *http.Request) {
+	if !requireUIDs(w, r.PathValue("studyUID")) {
+		return
+	}
 	objects, err := s.params.Store.RetrieveStudy(r.Context(), r.PathValue("studyUID"))
 	if err != nil {
 		httpError(w, err, http.StatusNotFound)
@@ -175,6 +180,9 @@ func (s *wadoServer) retrieveStudy(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *wadoServer) retrieveSeries(w http.ResponseWriter, r *http.Request) {
+	if !requireUIDs(w, r.PathValue("studyUID"), r.PathValue("seriesUID")) {
+		return
+	}
 	objects, err := s.params.Store.RetrieveSeries(r.Context(),
 		r.PathValue("studyUID"), r.PathValue("seriesUID"))
 	if err != nil {
@@ -185,6 +193,9 @@ func (s *wadoServer) retrieveSeries(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *wadoServer) retrieveInstance(w http.ResponseWriter, r *http.Request) {
+	if !requireUIDs(w, r.PathValue("studyUID"), r.PathValue("seriesUID"), r.PathValue("sopInstanceUID")) {
+		return
+	}
 	obj, err := s.params.Store.RetrieveInstance(r.Context(),
 		r.PathValue("studyUID"), r.PathValue("seriesUID"), r.PathValue("sopInstanceUID"))
 	if err != nil {
@@ -195,6 +206,9 @@ func (s *wadoServer) retrieveInstance(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *wadoServer) retrieveStudyMetadata(w http.ResponseWriter, r *http.Request) {
+	if !requireUIDs(w, r.PathValue("studyUID")) {
+		return
+	}
 	objects, err := s.params.Store.RetrieveStudy(r.Context(), r.PathValue("studyUID"))
 	if err != nil {
 		httpError(w, err, http.StatusNotFound)
@@ -204,6 +218,9 @@ func (s *wadoServer) retrieveStudyMetadata(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *wadoServer) retrieveSeriesMetadata(w http.ResponseWriter, r *http.Request) {
+	if !requireUIDs(w, r.PathValue("studyUID"), r.PathValue("seriesUID")) {
+		return
+	}
 	objects, err := s.params.Store.RetrieveSeries(r.Context(),
 		r.PathValue("studyUID"), r.PathValue("seriesUID"))
 	if err != nil {
@@ -214,6 +231,9 @@ func (s *wadoServer) retrieveSeriesMetadata(w http.ResponseWriter, r *http.Reque
 }
 
 func (s *wadoServer) retrieveInstanceMetadata(w http.ResponseWriter, r *http.Request) {
+	if !requireUIDs(w, r.PathValue("studyUID"), r.PathValue("seriesUID"), r.PathValue("sopInstanceUID")) {
+		return
+	}
 	obj, err := s.params.Store.RetrieveInstance(r.Context(),
 		r.PathValue("studyUID"), r.PathValue("seriesUID"), r.PathValue("sopInstanceUID"))
 	if err != nil {
@@ -226,6 +246,9 @@ func (s *wadoServer) retrieveInstanceMetadata(w http.ResponseWriter, r *http.Req
 // retrieveFrames handles WADO-RS frame-level retrieval.
 // The {frames} path segment is a comma-separated list of 1-based frame numbers.
 func (s *wadoServer) retrieveFrames(w http.ResponseWriter, r *http.Request) {
+	if !requireUIDs(w, r.PathValue("studyUID"), r.PathValue("seriesUID"), r.PathValue("sopInstanceUID")) {
+		return
+	}
 	obj, err := s.params.Store.RetrieveInstance(r.Context(),
 		r.PathValue("studyUID"), r.PathValue("seriesUID"), r.PathValue("sopInstanceUID"))
 	if err != nil {
@@ -278,30 +301,68 @@ func (s *wadoServer) storeInstances(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing multipart boundary", http.StatusBadRequest)
 		return
 	}
-	mr := multipart.NewReader(r.Body, boundary)
+	// Bound the request body as a whole; each part is separately capped by
+	// limitedReadAll.
+	mr := multipart.NewReader(http.MaxBytesReader(w, r.Body, maxStoreBodyBytes), boundary)
 	var objects []media.DICOMObject
+	failed := 0
 	for {
 		part, partErr := mr.NextPart()
 		if partErr != nil {
-			break
+			if errors.Is(partErr, io.EOF) {
+				break
+			}
+			// A malformed or over-large body is a client error, not the end of
+			// the stream. Treating every NextPart error as "done" is what let a
+			// truncated upload report success for the parts that happened to
+			// arrive first.
+			http.Error(w, "malformed multipart body", http.StatusBadRequest)
+			return
+		}
+		if len(objects)+failed >= maxStoreParts {
+			http.Error(w, "too many parts", http.StatusRequestEntityTooLarge)
+			return
 		}
 		data, readErr := limitedReadAll(part)
 		if readErr != nil {
+			slog.Warn("STOW-RS: failed to read part", "err", readErr)
+			failed++
 			continue
 		}
 		obj, parseErr := media.NewDCMObjFromBytes(data)
 		if parseErr != nil {
 			slog.Warn("STOW-RS: failed to parse DICOM part", "err", parseErr)
+			failed++
 			continue
 		}
 		objects = append(objects, obj)
+	}
+
+	// PS3.18 §10.5: nothing stored is a failure, not a success. Returning 200
+	// with an empty ReferencedSOPSequence told a sending modality its study was
+	// safely archived when none of it was — and a modality that then deletes its
+	// local copy loses the study.
+	if len(objects) == 0 {
+		if failed > 0 {
+			http.Error(w, "no instances could be stored", http.StatusConflict)
+			return
+		}
+		http.Error(w, "no DICOM instances in request", http.StatusBadRequest)
+		return
 	}
 	if storeErr := s.params.Store.StoreInstances(r.Context(), objects); storeErr != nil {
 		httpError(w, storeErr, http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/dicom+json")
-	w.WriteHeader(http.StatusOK)
+	// PS3.18 §10.5: partial success is 202 Accepted, so a client can tell that
+	// some instances did not make it rather than assuming the whole study landed.
+	if failed > 0 {
+		slog.Warn("STOW-RS: partial store", "stored", len(objects), "failed", failed)
+		w.WriteHeader(http.StatusAccepted)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
 	_ = json.NewEncoder(w).Encode(buildStowResponse(objects))
 }
 
@@ -466,6 +527,9 @@ func httpError(w http.ResponseWriter, err error, code int) {
 // ── WADO-RS delete handlers ───────────────────────────────────────────────────
 
 func (s *wadoServer) deleteStudy(w http.ResponseWriter, r *http.Request) {
+	if !requireUIDs(w, r.PathValue("studyUID")) {
+		return
+	}
 	if err := s.params.Store.DeleteStudy(r.Context(), r.PathValue("studyUID")); err != nil {
 		httpError(w, err, http.StatusNotFound)
 		return
@@ -474,6 +538,9 @@ func (s *wadoServer) deleteStudy(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *wadoServer) deleteSeries(w http.ResponseWriter, r *http.Request) {
+	if !requireUIDs(w, r.PathValue("studyUID"), r.PathValue("seriesUID")) {
+		return
+	}
 	if err := s.params.Store.DeleteSeries(r.Context(),
 		r.PathValue("studyUID"), r.PathValue("seriesUID")); err != nil {
 		httpError(w, err, http.StatusNotFound)
@@ -483,6 +550,9 @@ func (s *wadoServer) deleteSeries(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *wadoServer) deleteInstance(w http.ResponseWriter, r *http.Request) {
+	if !requireUIDs(w, r.PathValue("studyUID"), r.PathValue("seriesUID"), r.PathValue("sopInstanceUID")) {
+		return
+	}
 	if err := s.params.Store.DeleteInstance(r.Context(),
 		r.PathValue("studyUID"), r.PathValue("seriesUID"), r.PathValue("sopInstanceUID")); err != nil {
 		httpError(w, err, http.StatusNotFound)
@@ -494,6 +564,57 @@ func (s *wadoServer) deleteInstance(w http.ResponseWriter, r *http.Request) {
 // limitedReadAll reads at most 64 MiB from r to prevent memory exhaustion.
 const maxPartBytes = 64 * 1024 * 1024
 
+// maxStoreBodyBytes and maxStoreParts bound a STOW-RS upload as a whole.
+// maxPartBytes caps each part, but nothing capped how many parts arrived or the
+// total body, and every parsed object was accumulated before any was handed to
+// the Store: a 1 GB body of 2000 parts held ~1.6 GB resident, with no ceiling
+// other than the client's patience.
+const (
+	maxStoreBodyBytes = 2 << 30 // 2 GiB
+	maxStoreParts     = 10000
+)
+
+// limitedReadAll reads at most maxPartBytes and reports whether the limit was
+// hit, rather than silently returning a truncated part. A truncated DICOM
+// payload fails to parse, so previously an oversized part vanished into the
+// "skip and keep going" path and the response still said 200.
 func limitedReadAll(r io.Reader) ([]byte, error) {
-	return io.ReadAll(io.LimitReader(r, maxPartBytes))
+	data, err := io.ReadAll(io.LimitReader(r, maxPartBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxPartBytes {
+		return nil, fmt.Errorf("part exceeds %d bytes", maxPartBytes)
+	}
+	return data, nil
+}
+
+// uidPattern is the DICOM UI value representation: dot-separated numeric
+// components, at most 64 characters (PS3.5 §9.1).
+var uidPattern = regexp.MustCompile(`^[0-9]+(\.[0-9]+)*$`)
+
+// validUID reports whether s is a syntactically valid DICOM UID.
+//
+// Go's ServeMux percent-decodes path wildcards, so a request for
+// `..%2f..%2f..%2fetc%2fpasswd` reaches the handler as the literal string
+// `../../../etc/passwd`, and `a%00b` arrives with an embedded NUL. Those went
+// to the Store verbatim. io-scp's Store resolves UIDs through a query engine so
+// it is unaffected, but the Store interface documents no validation obligation,
+// and the canonical DICOM layout is {studyUID}/{seriesUID}/{sopUID}.dcm — any
+// filesystem- or object-store-backed implementation would inherit an arbitrary
+// read/delete primitive.
+func validUID(s string) bool {
+	return s != "" && len(s) <= 64 && uidPattern.MatchString(s)
+}
+
+// requireUIDs validates every supplied path UID, writing 400 and returning
+// false on the first invalid one.
+func requireUIDs(w http.ResponseWriter, uids ...string) bool {
+	for _, uid := range uids {
+		if !validUID(uid) {
+			http.Error(w, "invalid DICOM UID in request path", http.StatusBadRequest)
+			return false
+		}
+	}
+	return true
 }

--- a/wado/server_test.go
+++ b/wado/server_test.go
@@ -108,7 +108,7 @@ func newTestHandler(t *testing.T) (http.Handler, *mockStore) {
 func TestRetrieveStudy_NotFound(t *testing.T) {
 	h, _ := newTestHandler(t)
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest("GET", "/wado/rs/studies/1.2.3.missing", nil))
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/wado/rs/studies/1.2.3.999999", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("want 404, got %d", rec.Code)
 	}


### PR DESCRIPTION
## Three findings in the DICOMweb HTTP surface, all reproduced

### 1. 🔴 UID path segments reached the Store unvalidated

Go's `ServeMux` **percent-decodes** path wildcards, so a request for `..%2f..%2f..%2fetc%2fpasswd` arrives at the handler as the literal string `../../../etc/passwd`, and `a%00b` arrives with an embedded NUL. Both went to the `Store` **verbatim**, on every retrieve, metadata and **DELETE** handler.

io-scp's Store resolves UIDs through the query engine and is not affected — but the `Store` interface documents **no validation obligation**, and the canonical DICOM layout is `{studyUID}/{seriesUID}/{sopUID}.dcm`, so any filesystem- or object-store-backed implementation inherits an arbitrary read/delete primitive.

Now validated against PS3.5 §9.1 (dot-separated numeric components, ≤64 chars) in all ten handlers → 400.

### 2. STOW-RS uploads were unbounded

`maxPartBytes` capped each part, but **nothing capped the number of parts or the total body**, and every parsed object was accumulated before any reached the Store — an audit measured a 1 GB body of 2000 parts holding **~1.6 GB resident**. Added `http.MaxBytesReader` over the body plus a part-count ceiling.

`limitedReadAll` also silently **truncated** at the cap; the truncated DICOM then failed to parse and the part vanished into the skip-and-continue path. It now reports the overflow.

### 3. 🔴 STOW-RS returned 200 when nothing was stored — data loss

Parts that failed to read or parse were skipped with `continue`, and the handler **unconditionally wrote 200** with an empty `ReferencedSOPSequence`. A modality that treats 200 as "safely archived" and deletes its local copy **loses the study**.

Per PS3.18 §10.5: nothing stored is now **409** (or 400 for an empty request), partial success is **202**, and a mid-stream multipart error is **400** rather than being mistaken for end-of-stream.

`wado.Client.StoreInstances` now returns early for an empty slice instead of POSTing an empty body, which that change would otherwise reject.

## ⚠️ Deliberate behaviour change

A **syntactically invalid UID is now 400 where it used to be 404.** One existing test used `"1.2.3.missing"` — a non-numeric component, so not a valid UID — as a stand-in for an absent study; it now uses `"1.2.3.999999"`. Deployments using non-conformant UIDs would see 400s, but PS3.5 §9.1 is unambiguous and this is the traversal fix.

## Verification

Each attack is driven through the real handler, and the tests were confirmed to **fail with the protections neutered**:

```
GET    /wado/rs/studies/..%2f..%2f..%2fetc%2fpasswd            got 404; the UID reached the Store
GET    /wado/rs/studies/..%2f..%2f..%2fetc%2fpasswd/metadata   got 404; the UID reached the Store
GET    /wado/rs/studies/1.2.3/series/..%2f..%2f..%2fetc%2f...  got 404; the UID reached the Store
DELETE /wado/rs/studies/..%2f..%2f..%2fetc%2fpasswd            got 404; the UID reached the Store
DELETE /wado/rs/studies/1.2.3/series/1.2.4/instances/..%2f...  got 404; the UID reached the Store
```

My first version of these assertions was too lenient — it accepted 404 (which *is* the vulnerability) and 202. Tightened so only 400, or a 3xx from ServeMux normalisation, passes.

Full suite green, `go vet` clean, all three consumers build and test green.

## Still open in wado/conformance

Not addressed here: the client interpolates UIDs into URLs without escaping (`DeleteStudy` can be redirected to another endpoint); client-side multipart parts are read with unbounded `io.ReadAll`; STOW ignores the `{studyUID}` path segment entirely (PS3.18 requires rejecting a mismatch); and the conformance validator returns `compliant: true, PASS` for `Rows:-5, Columns:1e18`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)