### PR TITLE
fix(conformance): stop certifying impossible and malformed objects

### DIFF
--- a/conformance/validator.go
+++ b/conformance/validator.go
@@ -2,8 +2,11 @@ package conformance
 
 import (
 	"fmt"
+	"math"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // ConformanceValidator validates DICOM files for standards compliance
@@ -92,14 +95,30 @@ func (cv *ConformanceValidator) ValidateDICOMMetadata(metadata map[string]interf
 			Actual:      "missing",
 			Description: "SOP Class UID is mandatory and must be a valid DICOM UID",
 		})
-	} else if !strings.HasPrefix(sopClassUID, "1.2.840.10008") {
+	} else if !isValidUID(sopClassUID) {
+		// Syntax is what makes a UID valid or not (PS3.5 §9.1). The previous
+		// check tested only a "1.2.840.10008" prefix with no separating dot, so
+		// "1.2.840.100081.6.6.6" (a different arc entirely) and
+		// "1.2.840.10008/../../../etc/passwd" were both certified conformant.
 		findings = append(findings, Finding{
 			RuleID:      "DICOM-004",
 			Severity:    "error",
 			Element:     "SOP Class UID (0008,0016)",
-			Expected:    "1.2.840.10008.* UID",
+			Expected:    "dot-separated numeric components, at most 64 characters",
 			Actual:      sopClassUID,
-			Description: "SOP Class UID must be a valid DICOM UID starting with 1.2.840.10008",
+			Description: "SOP Class UID is not a syntactically valid DICOM UID (PS3.5 §9.1)",
+		})
+	} else if !strings.HasPrefix(sopClassUID, "1.2.840.10008.") {
+		// Private and vendor SOP Classes live outside the standard arc and are
+		// entirely legal, so this is informational rather than a failure — as an
+		// error it failed every archive holding vendor-private objects.
+		findings = append(findings, Finding{
+			RuleID:      "DICOM-004",
+			Severity:    "info",
+			Element:     "SOP Class UID (0008,0016)",
+			Expected:    "1.2.840.10008.* for standard SOP Classes",
+			Actual:      sopClassUID,
+			Description: "SOP Class UID is outside the DICOM standard arc (private or vendor-defined)",
 		})
 	}
 
@@ -109,11 +128,11 @@ func (cv *ConformanceValidator) ValidateDICOMMetadata(metadata map[string]interf
 			RuleID:      "DICOM-005",
 			Severity:    "error",
 			Element:     "Bits Allocated (0028,0100)",
-			Expected:    "8, 16, or 32",
+			Expected:    "1 or a multiple of 8",
 			Actual:      "missing or invalid type",
-			Description: "Bits Allocated is mandatory and must be 8, 16, or 32",
+			Description: "Bits Allocated is mandatory and must be 1 or a multiple of 8 (PS3.5 §8.1.1)",
 		})
-	} else if bitsAlloc != 8 && bitsAlloc != 16 && bitsAlloc != 32 {
+	} else if bitsAlloc != 1 && (bitsAlloc < 8 || bitsAlloc > 64 || math.Mod(bitsAlloc, 8) != 0) {
 		findings = append(findings, Finding{
 			RuleID:      "DICOM-005",
 			Severity:    "error",
@@ -210,10 +229,14 @@ func (cv *ConformanceValidator) ValidatePixelData(pixelData map[string]interface
 	findings := []Finding{}
 
 	// Rule P1: Rows present (warning — pixel data exists but attribute is unavailable)
-	if rows, ok := pixelData["Rows"].(float64); !ok || rows == 0 {
+	if rows, ok := pixelData["Rows"].(float64); !ok || rows <= 0 || rows > maxPlausibleDimension {
+		// Type 1 (PS3.3 C.7.6.3), so absence is an error, not a warning. The
+		// previous test was `rows == 0`, which passed negative values straight
+		// through: {Rows:-5, Columns:1e18} was certified compliant, and that is
+		// precisely the shape that overflows a downstream buffer computation.
 		findings = append(findings, Finding{
 			RuleID:      "DICOM-P001",
-			Severity:    "warning",
+			Severity:    "error",
 			Element:     "Rows (0028,0010)",
 			Expected:    "positive integer",
 			Actual:      "missing or zero",
@@ -221,10 +244,10 @@ func (cv *ConformanceValidator) ValidatePixelData(pixelData map[string]interface
 		})
 	}
 
-	if cols, ok := pixelData["Columns"].(float64); !ok || cols == 0 {
+	if cols, ok := pixelData["Columns"].(float64); !ok || cols <= 0 || cols > maxPlausibleDimension {
 		findings = append(findings, Finding{
 			RuleID:      "DICOM-P002",
-			Severity:    "warning",
+			Severity:    "error",
 			Element:     "Columns (0028,0011)",
 			Expected:    "positive integer",
 			Actual:      "missing or zero",
@@ -233,10 +256,12 @@ func (cv *ConformanceValidator) ValidatePixelData(pixelData map[string]interface
 	}
 
 	// Rule P3: SamplesPerPixel present
-	if samples, ok := pixelData["SamplesPerPixel"].(float64); !ok || samples == 0 {
+	if samples, ok := pixelData["SamplesPerPixel"].(float64); !ok || (samples != 1 && samples != 3) {
+		// The rule already advertised "1 (grayscale) or 3 (color)" but only ever
+		// checked presence, so SamplesPerPixel:7 passed.
 		findings = append(findings, Finding{
 			RuleID:      "DICOM-P003",
-			Severity:    "warning",
+			Severity:    "error",
 			Element:     "Samples Per Pixel (0028,0002)",
 			Expected:    "1 (grayscale) or 3 (color)",
 			Actual:      "missing or zero",
@@ -245,10 +270,11 @@ func (cv *ConformanceValidator) ValidatePixelData(pixelData map[string]interface
 	}
 
 	// Rule P4: BitsAllocated present
-	if bitsAlloc, ok := pixelData["BitsAllocated"].(float64); !ok || bitsAlloc == 0 {
+	if bitsAlloc, ok := pixelData["BitsAllocated"].(float64); !ok || bitsAlloc <= 0 ||
+		(bitsAlloc != 1 && (bitsAlloc < 8 || bitsAlloc > 64 || math.Mod(bitsAlloc, 8) != 0)) {
 		findings = append(findings, Finding{
 			RuleID:      "DICOM-P004",
-			Severity:    "warning",
+			Severity:    "error",
 			Element:     "Bits Allocated (0028,0100)",
 			Expected:    "8, 16, or 32",
 			Actual:      "missing or zero",
@@ -286,14 +312,21 @@ func (cv *ConformanceValidator) ValidatePixelData(pixelData map[string]interface
 
 	// Rule P7: Photometric Interpretation valid
 	if photoInterp, ok := pixelData["PhotometricInterpretation"].(string); ok {
+		// PS3.3 C.7.6.3.1.2. The previous map omitted PALETTE COLOR,
+		// YBR_FULL_422, YBR_PARTIAL_422 and YBR_PARTIAL_420 — flagging the
+		// common JPEG colour case as non-conformant — while accepting
+		// "YBR_PARTIAL", which is not an enumerated value.
 		validInterps := map[string]bool{
-			"MONOCHROME1": true,
-			"MONOCHROME2": true,
-			"RGB":         true,
-			"YBR_FULL":    true,
-			"YBR_PARTIAL": true,
-			"YBR_ICT":     true,
-			"YBR_RCT":     true,
+			"MONOCHROME1":     true,
+			"MONOCHROME2":     true,
+			"PALETTE COLOR":   true,
+			"RGB":             true,
+			"YBR_FULL":        true,
+			"YBR_FULL_422":    true,
+			"YBR_PARTIAL_422": true,
+			"YBR_PARTIAL_420": true,
+			"YBR_ICT":         true,
+			"YBR_RCT":         true,
 		}
 		if !validInterps[photoInterp] {
 			findings = append(findings, Finding{
@@ -324,6 +357,11 @@ func (cv *ConformanceValidator) GetConformanceReport(findings []Finding) map[str
 			warningCount++
 		case "info":
 			infoCount++
+		default:
+			// Fail closed: an unrecognised severity (a typo, or a new level added
+			// later) previously counted toward nothing and so could never fail a
+			// verdict while still appearing in total_findings.
+			errorCount++
 		}
 	}
 
@@ -356,19 +394,27 @@ func (cv *ConformanceValidator) GetConformanceReport(findings []Finding) map[str
 // Helper functions
 
 func isValidDate(dateStr string) bool {
-	if len(dateStr) != 8 {
-		return false
-	}
-	matched, _ := regexp.MatchString(`^\d{8}$`, dateStr)
-	return matched
+	// Parse rather than pattern-match: ^\d{8}$ accepted 99999999 and 20231345
+	// (month 13, day 45) as valid DICOM dates.
+	_, err := time.Parse("20060102", dateStr)
+	return err == nil
 }
 
+// dicomTimePattern is anchored at both ends: the previous `^\d{6}` matched any
+// 6..14 byte value that merely started with six digits, so "123456<script>" was
+// reported as a valid DICOM TM.
+var dicomTimePattern = regexp.MustCompile(`^(\d{2})(\d{2})(\d{2})(\.\d{1,6})?$`)
+
 func isValidTime(timeStr string) bool {
-	if len(timeStr) < 6 || len(timeStr) > 14 {
+	m := dicomTimePattern.FindStringSubmatch(timeStr)
+	if m == nil {
 		return false
 	}
-	matched, _ := regexp.MatchString(`^\d{6}`, timeStr)
-	return matched
+	hh, _ := strconv.Atoi(m[1])
+	mm, _ := strconv.Atoi(m[2])
+	ss, _ := strconv.Atoi(m[3])
+	// Seconds may reach 60 for a leap second (PS3.5 Table 6.2-1).
+	return hh < 24 && mm < 60 && ss <= 60
 }
 
 func isColorModality(photoInterp string) bool {
@@ -379,4 +425,18 @@ func isColorModality(photoInterp string) bool {
 		"YBR_RCT":  true,
 	}
 	return colorModes[photoInterp]
+}
+
+// maxPlausibleDimension bounds Rows/Columns. It is deliberately far above any
+// real modality output while still rejecting the absurd values that overflow a
+// downstream rows*cols*bits computation.
+const maxPlausibleDimension = 1 << 20
+
+// uidSyntax is the DICOM UI value representation: dot-separated numeric
+// components, at most 64 characters (PS3.5 §9.1).
+var uidSyntax = regexp.MustCompile(`^[0-9]+(\.[0-9]+)*$`)
+
+// isValidUID reports whether s is a syntactically valid DICOM UID.
+func isValidUID(s string) bool {
+	return s != "" && len(s) <= 64 && uidSyntax.MatchString(s)
 }

--- a/conformance/validator_rules_test.go
+++ b/conformance/validator_rules_test.go
@@ -1,0 +1,224 @@
+package conformance
+
+import (
+	"testing"
+)
+
+// report runs the pixel-data rules and returns the summary counts.
+func pixelReport(t *testing.T, pd map[string]interface{}) (errors int, compliant bool) {
+	t.Helper()
+	v := NewConformanceValidator()
+	rep := v.GetConformanceReport(v.ValidatePixelData(pd))
+	return rep["error_count"].(int), rep["compliant"].(bool)
+}
+
+// TestImpossiblePixelGeometryIsNotCompliant is the headline correction: the
+// validator used to return compliant/PASS for geometry that cannot describe an
+// image. Rows was tested with `== 0`, so negative values passed; SamplesPerPixel
+// and BitsAllocated were presence-only despite advertising value constraints.
+//
+// {Rows:-5, Columns:1e18} is exactly the shape that overflows a downstream
+// rows*cols*bits computation, and this validator blessed it.
+func TestImpossiblePixelGeometryIsNotCompliant(t *testing.T) {
+	cases := []struct {
+		name string
+		pd   map[string]interface{}
+	}{
+		{"negative rows and absurd columns", map[string]interface{}{
+			"Rows": float64(-5), "Columns": float64(1e18),
+			"SamplesPerPixel": float64(7), "BitsAllocated": float64(3),
+			"BitsStored": float64(3), "PhotometricInterpretation": "MONOCHROME2",
+		}},
+		{"zero rows", map[string]interface{}{
+			"Rows": float64(0), "Columns": float64(512),
+			"SamplesPerPixel": float64(1), "BitsAllocated": float64(16),
+			"BitsStored": float64(12),
+		}},
+		{"samples per pixel of 7", map[string]interface{}{
+			"Rows": float64(512), "Columns": float64(512),
+			"SamplesPerPixel": float64(7), "BitsAllocated": float64(8),
+			"BitsStored": float64(8),
+		}},
+		{"bits allocated of 3", map[string]interface{}{
+			"Rows": float64(512), "Columns": float64(512),
+			"SamplesPerPixel": float64(1), "BitsAllocated": float64(3),
+			"BitsStored": float64(3),
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs, compliant := pixelReport(t, tc.pd)
+			if compliant || errs == 0 {
+				t.Fatalf("impossible geometry reported compliant=%v with %d errors", compliant, errs)
+			}
+		})
+	}
+}
+
+// TestLegalPixelGeometryStillPasses guards the tightened rules from rejecting
+// real objects, including the 1-bit and 64-bit cases PS3.5 §8.1.1 permits.
+func TestLegalPixelGeometryStillPasses(t *testing.T) {
+	cases := []struct {
+		name string
+		pd   map[string]interface{}
+	}{
+		{"8-bit grayscale", map[string]interface{}{
+			"Rows": float64(512), "Columns": float64(512),
+			"SamplesPerPixel": float64(1), "BitsAllocated": float64(8),
+			"BitsStored": float64(8), "PhotometricInterpretation": "MONOCHROME2",
+		}},
+		{"16-bit grayscale", map[string]interface{}{
+			"Rows": float64(512), "Columns": float64(512),
+			"SamplesPerPixel": float64(1), "BitsAllocated": float64(16),
+			"BitsStored": float64(12), "PhotometricInterpretation": "MONOCHROME1",
+		}},
+		{"1-bit segmentation", map[string]interface{}{
+			"Rows": float64(256), "Columns": float64(256),
+			"SamplesPerPixel": float64(1), "BitsAllocated": float64(1),
+			"BitsStored": float64(1), "PhotometricInterpretation": "MONOCHROME2",
+		}},
+		{"RGB colour", map[string]interface{}{
+			"Rows": float64(640), "Columns": float64(480),
+			"SamplesPerPixel": float64(3), "BitsAllocated": float64(8),
+			"BitsStored": float64(8), "PhotometricInterpretation": "RGB",
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if errs, compliant := pixelReport(t, tc.pd); !compliant || errs != 0 {
+				t.Fatalf("valid geometry rejected: compliant=%v errors=%d", compliant, errs)
+			}
+		})
+	}
+}
+
+// TestPhotometricInterpretationEnumeration covers the values PS3.3 C.7.6.3.1.2
+// enumerates. The previous whitelist omitted four of them — flagging the common
+// JPEG colour case YBR_FULL_422 as non-conformant — while accepting
+// "YBR_PARTIAL", which is not an enumerated value.
+func TestPhotometricInterpretationEnumeration(t *testing.T) {
+	base := func(pi string) map[string]interface{} {
+		return map[string]interface{}{
+			"Rows": float64(64), "Columns": float64(64),
+			"SamplesPerPixel": float64(3), "BitsAllocated": float64(8),
+			"BitsStored": float64(8), "PhotometricInterpretation": pi,
+		}
+	}
+	for _, pi := range []string{
+		"MONOCHROME1", "MONOCHROME2", "PALETTE COLOR", "RGB",
+		"YBR_FULL", "YBR_FULL_422", "YBR_PARTIAL_422", "YBR_PARTIAL_420",
+		"YBR_ICT", "YBR_RCT",
+	} {
+		v := NewConformanceValidator()
+		for _, f := range v.ValidatePixelData(base(pi)) {
+			if f.RuleID == "DICOM-P007" {
+				t.Errorf("standard photometric interpretation %q was flagged", pi)
+			}
+		}
+	}
+	// Not an enumerated value; it must be flagged.
+	v := NewConformanceValidator()
+	flagged := false
+	for _, f := range v.ValidatePixelData(base("YBR_PARTIAL")) {
+		if f.RuleID == "DICOM-P007" {
+			flagged = true
+		}
+	}
+	if !flagged {
+		t.Error(`"YBR_PARTIAL" is not an enumerated value but was accepted`)
+	}
+}
+
+// TestUIDSyntaxValidation covers the SOP Class rule. The old prefix test had no
+// separating dot, so a different registration arc passed, and no rule checked
+// UID syntax at all — a path-traversal string was certified conformant.
+func TestUIDSyntaxValidation(t *testing.T) {
+	invalid := []string{
+		"1.2.840.10008/../../../etc/passwd",
+		"1.2.840.10008EVIL",
+		"not-a-uid",
+		"1.2.3.",
+		"",
+	}
+	for _, uid := range invalid {
+		if isValidUID(uid) {
+			t.Errorf("invalid UID %q accepted", uid)
+		}
+	}
+	valid := []string{
+		"1.2.840.10008.5.1.4.1.1.2",
+		"1.3.46.670589.11.0.0.12.1",    // Philips private
+		"1.2.826.0.1.3680043.2.1125.1", // Medical Connections private
+		"1",
+	}
+	for _, uid := range valid {
+		if !isValidUID(uid) {
+			t.Errorf("valid UID %q rejected", uid)
+		}
+	}
+	// A UID over 64 characters is invalid per PS3.5 §9.1.
+	long := "1." + string(make([]byte, 0))
+	for len(long) <= 64 {
+		long += "1"
+	}
+	if isValidUID(long) {
+		t.Errorf("UID of %d characters accepted", len(long))
+	}
+}
+
+// TestPrivateSOPClassIsNotAnError pins the correction that private and vendor
+// SOP Classes are legal DICOM. Reporting them as errors gave a blanket FAIL to
+// any archive holding vendor-private objects.
+func TestPrivateSOPClassIsNotAnError(t *testing.T) {
+	v := NewConformanceValidator()
+	findings := v.ValidateDICOMMetadata(map[string]interface{}{
+		"SOPClassUID": "1.3.46.670589.11.0.0.12.1",
+	})
+	for _, f := range findings {
+		if f.RuleID == "DICOM-004" && f.Severity == "error" {
+			t.Fatalf("a legal private SOP Class was reported as an error: %s", f.Description)
+		}
+	}
+}
+
+// TestDateAndTimeValidation covers the anchoring and range fixes. The time
+// pattern was unanchored at the end, so any 6..14 byte value starting with six
+// digits was "valid"; the date pattern accepted impossible calendar values.
+func TestDateAndTimeValidation(t *testing.T) {
+	for _, bad := range []string{"123456<script>", "1234567890abcd", "999999", "246199", "12345"} {
+		if isValidTime(bad) {
+			t.Errorf("invalid time %q accepted", bad)
+		}
+	}
+	for _, good := range []string{"000000", "235959", "120000.123456", "235960"} {
+		if !isValidTime(good) {
+			t.Errorf("valid time %q rejected", good)
+		}
+	}
+	for _, bad := range []string{"99999999", "00000000", "20231345", "2023121"} {
+		if isValidDate(bad) {
+			t.Errorf("invalid date %q accepted", bad)
+		}
+	}
+	for _, good := range []string{"20231215", "20000229"} { // 2000 was a leap year
+		if !isValidDate(good) {
+			t.Errorf("valid date %q rejected", good)
+		}
+	}
+}
+
+// TestUnknownSeverityFailsClosed pins the severity switch default. An
+// unrecognised severity previously counted toward nothing, so it could never
+// fail a verdict while still appearing in total_findings.
+func TestUnknownSeverityFailsClosed(t *testing.T) {
+	v := NewConformanceValidator()
+	rep := v.GetConformanceReport([]Finding{
+		{RuleID: "X1", Severity: "ERROR"},    // wrong case
+		{RuleID: "X2", Severity: "critical"}, // unknown level
+	})
+	if rep["compliant"].(bool) {
+		t.Fatalf("unknown severities were treated as non-blocking: %v", rep)
+	}
+}

--- a/conformance/validator_test.go
+++ b/conformance/validator_test.go
@@ -108,14 +108,20 @@ func TestValidatePixelData(t *testing.T) {
 				"BitsAllocated":   float64(16),
 				"BitsStored":      float64(12),
 			},
-			expectErrors:   0,
-			expectWarnings: 1,
+			// Rows is Type 1, so its absence is an error rather than a warning.
+			expectErrors:   1,
+			expectWarnings: 0,
 		},
 		{
-			name:           "Missing all pixel attributes",
-			pixelData:      map[string]interface{}{},
-			expectErrors:   0,
-			expectWarnings: 5, // Rows, Columns, SamplesPerPixel, BitsAllocated, BitsStored
+			name:      "Missing all pixel attributes",
+			pixelData: map[string]interface{}{},
+			// Rows, Columns, SamplesPerPixel and BitsAllocated are Type 1
+			// (PS3.3 C.7.6.3): an object carrying Pixel Data without them is not
+			// renderable, so their absence is an error. BitsStored remains a
+			// warning. This previously reported 0 errors, which meant an object
+			// with no pixel geometry at all was certified compliant.
+			expectErrors:   4,
+			expectWarnings: 1,
 		},
 		{
 			name: "BitsStored exceeds BitsAllocated",


### PR DESCRIPTION
## The validator returned PASS for objects that cannot describe an image

This matters because callers act on the verdict — io-scp exposes it through its validate endpoint.

### 1. 🔴 Type 1 pixel attributes were warnings, and only tested for presence

Rows, Columns, SamplesPerPixel and BitsAllocated are **Type 1** (PS3.3 C.7.6.3) — an object carrying Pixel Data without them is not renderable. All four produced *warnings*, so `error_count` stayed 0 and the object passed. Worse, Rows was tested with `== 0`, so **negative values went straight through**, and SamplesPerPixel/BitsAllocated were presence-only despite the rules advertising value constraints:

```
{Rows:-5, Columns:1e18, SamplesPerPixel:7, BitsAllocated:3}  ->  compliant: true, PASS
```

That is exactly the shape that overflows a downstream `rows*cols*bits` computation — and the validator blessed it. Now errors, with range checks: positive and bounded dimensions, SamplesPerPixel ∈ {1,3}, BitsAllocated 1 or a multiple of 8.

### 2. SOP Class UID checking was wrong in **both** directions

The prefix test had **no separating dot**, so `1.2.840.100081.6.6.6` — a different registration arc — was accepted, and nothing validated UID syntax at all:

```
SOPClassUID = "1.2.840.10008/../../../etc/passwd"  ->  compliant: true, score 1.0
```

Meanwhile **legal private SOP Classes** (Philips, Medical Connections) were reported as hard errors, giving a blanket FAIL to any archive holding vendor-private objects.

Syntax (PS3.5 §9.1) is now the error; being outside the standard arc is informational.

### 3. BitsAllocated contradicted PS3.5 §8.1.1

`{8,16,32}` rejected **1** (BINARY Segmentation) and **64** (Double Float Pixel Data), both legal. The rule is 1 or a multiple of 8.

### 4. Photometric Interpretation whitelist was wrong in both directions

Missing `PALETTE COLOR`, `YBR_FULL_422`, `YBR_PARTIAL_422`, `YBR_PARTIAL_420` — so the **common JPEG colour case** was flagged — while accepting `YBR_PARTIAL`, which is not an enumerated value (PS3.3 C.7.6.3.1.2).

### 5. Unknown severities failed open

The severity switch had no `default`, so a mis-cased or newly-added severity counted toward nothing — it could never fail a verdict while still appearing in `total_findings`. Now counts as an error.

### 6. Date and time validation

`isValidTime`'s regex was **unanchored at the end**, so any 6–14 byte value starting with six digits was "a valid DICOM TM" — including `"123456<script>"` — and no field ranges were checked (`"246199"` passed). `isValidDate` accepted `99999999` and `20231345`. Both now parse and range-check.

## Verification

The new tests were confirmed to fail with the old Rows rule restored:

```
--- FAIL: TestImpossiblePixelGeometryIsNotCompliant/zero_rows
    impossible geometry reported compliant=true with 0 errors
```

Coverage includes: impossible geometry rejected; **legal** geometry still passing (8/16-bit, 1-bit segmentation, RGB); the full PS3.3 photometric enumeration accepted and `YBR_PARTIAL` flagged; UID syntax both directions including private arcs; date/time ranges; and unknown severities failing closed.

Full suite green, `go vet` clean, all three consumers build and test green.

## ⚠️ Behaviour change

Objects that previously passed will now fail if they lack Type 1 pixel attributes or carry impossible values — which is the point, but it will change verdicts for anything relying on the old leniency. Two existing test expectations encoded the old behaviour ("missing all pixel attributes → 0 errors", "missing Rows → warning") and were updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)