### PR TITLE
fix(transcoder): bound per-frame slices for JPIP and JPEG-LS encoding

### DIFF
--- a/media/multiframe_transcode_test.go
+++ b/media/multiframe_transcode_test.go
@@ -1,0 +1,130 @@
+package media_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/codecs"
+	"github.com/innovative-io/io-dicom/dictionary/tags"
+	"github.com/innovative-io/io-dicom/dictionary/transfersyntax"
+	"github.com/innovative-io/io-dicom/media"
+	"github.com/innovative-io/io-dicom/transcoder"
+)
+
+// useGoBackends selects the pure-Go codec backends for the duration of a test.
+func useGoBackends(t *testing.T) {
+	t.Helper()
+	if err := codecs.UseBackends(codecs.BackendConfig{
+		JPEG:     "gojpeg",
+		JPEGLS:   "gojpegls",
+		JPEG2000: "gojpeg2000",
+		JPIP:     "gojpip",
+		JPEGXL:   "gojpegxl",
+	}); err != nil {
+		t.Skipf("pure-Go codec backends unavailable: %v", err)
+	}
+}
+
+// newMultiFrameObject builds an uncompressed grayscale object with the given
+// number of frames.
+//
+// The representative round-trip matrix only ever exercises single-frame objects
+// (newMonoRoundTripObject hard-codes NumberOfFrames "1"), which is why a
+// transfer syntax that failed on every multi-frame input went unnoticed.
+func newMultiFrameObject(frames int, cols, rows int) media.DICOMObject {
+	obj := media.NewEmptyDCMObj()
+	obj.SetTransferSyntax(transfersyntax.ExplicitVRLittleEndian)
+	obj.SetExplicitVR(true)
+
+	obj.Write(tags.SOPClassUID, "1.2.840.10008.5.1.4.1.1.7")
+	obj.Write(tags.SOPInstanceUID, "1.2.826.0.1.3680043.10.90.5")
+	obj.Write(tags.PatientName, "ROUNDTRIP^MULTIFRAME")
+	obj.Write(tags.PatientID, "MF-01")
+	obj.Write(tags.PhotometricInterpretation, "MONOCHROME2")
+	obj.Write(tags.PlanarConfiguration, 0)
+	obj.Write(tags.NumberOfFrames, fmt.Sprintf("%d", frames))
+	obj.Write(tags.Rows, uint16(rows))
+	obj.Write(tags.Columns, uint16(cols))
+	obj.Write(tags.BitsAllocated, 8)
+	obj.Write(tags.BitsStored, 8)
+	obj.Write(tags.PixelRepresentation, 0)
+
+	n := frames * cols * rows
+	pixels := make([]byte, n)
+	for i := range pixels {
+		pixels[i] = byte(i*7 + 3)
+	}
+	obj.Add(&media.DICOMTag{
+		Group: 0x7FE0, Element: 0x0010,
+		Length: uint32(n), VR: "OB", Data: pixels,
+	})
+	return obj
+}
+
+// TestMultiFrameTranscodeAcrossSyntaxes covers the encoders with more than one
+// frame. JPIP passed frame 0's offset as img[offset:] — a slice running to the
+// end of the whole multi-frame buffer — where every other codec uses
+// frameBounds' [start,end). The encoder's exact-size check then rejected it, so
+// JPIP encoding failed for every object with more than one frame.
+func TestMultiFrameTranscodeAcrossSyntaxes(t *testing.T) {
+	// Establish the pure-Go backends explicitly rather than relying on ambient
+	// state. forceCodecBackends' cleanup in dicom_object_test.go restores every
+	// codec to "passthrough" rather than to its default, so any test running
+	// after it sees "no encode backend available" — this test passes in
+	// isolation and fails in a full package run without this.
+	useGoBackends(t)
+
+	syntaxes := []*transfersyntax.TransferSyntax{
+		transfersyntax.JPIPHTJ2KReferenced,
+		transfersyntax.HTJ2KLossless,
+		transfersyntax.JPEG2000Lossless,
+		transfersyntax.RLELossless,
+		transfersyntax.JPEGLSLossless,
+		transfersyntax.DeflatedImageFrameCompression,
+		transfersyntax.JPEGBaseline8Bit,
+		transfersyntax.JPEGLosslessSV1,
+		transfersyntax.JPEG2000,
+		transfersyntax.HTJ2K,
+		transfersyntax.JPEGXLLossless,
+	}
+
+	for _, ts := range syntaxes {
+		for _, frames := range []int{1, 2, 5} {
+			t.Run(fmt.Sprintf("%s/frames=%d", ts.Name, frames), func(t *testing.T) {
+				obj := newMultiFrameObject(frames, 16, 16)
+				if err := transcoder.ChangeTransferSyntax(obj, ts); err != nil {
+					t.Fatalf("ChangeTransferSyntax(%s) with %d frames: %v", ts.Name, frames, err)
+				}
+				if got := obj.GetTransferSyntax().UID; got != ts.UID {
+					t.Fatalf("transfer syntax not updated: got %s want %s", got, ts.UID)
+				}
+			})
+		}
+	}
+}
+
+// TestFailedTranscodeLeavesObjectIntact pins that a failing encode does not
+// leave the object half-converted. The JPIP branch called
+// beginEncapsulatedPixelData before its encode loop, so an error partway
+// through left the pixel-data tag rewritten to encapsulated form with no
+// sequence delimiter — neither the original object nor a valid result.
+func TestFailedTranscodeLeavesObjectIntact(t *testing.T) {
+	useGoBackends(t)
+	obj := newMultiFrameObject(3, 16, 16)
+	before := obj.GetTransferSyntax().UID
+	pixelBefore := obj.GetTagAt(obj.TagCount() - 1)
+	lengthBefore := pixelBefore.Length
+
+	// An unsupported target must fail without mutating the object.
+	err := transcoder.ChangeTransferSyntax(obj, transfersyntax.JPEGXLJPEGRecompression)
+	if err == nil {
+		t.Skip("target syntax unexpectedly supported for this input")
+	}
+	if got := obj.GetTransferSyntax().UID; got != before {
+		t.Fatalf("transfer syntax changed despite failure: %s -> %s", before, got)
+	}
+	pixelAfter := obj.GetTagAt(obj.TagCount() - 1)
+	if pixelAfter.Length == 0xFFFFFFFF && lengthBefore != 0xFFFFFFFF {
+		t.Fatal("pixel data was converted to encapsulated form despite the failure")
+	}
+}

--- a/transcoder/transcoder.go
+++ b/transcoder/transcoder.go
@@ -536,23 +536,23 @@ func compress(ctx context.Context, obj media.DICOMObject, i *int, img []byte, RG
 	case transfersyntax.JPEGLSLossless.UID:
 		fallthrough
 	case transfersyntax.JPEGLSNearLossless.UID:
-		index = beginEncapsulatedPixelData(obj, index)
+		// Encode every frame before mutating the object, and bound each frame to
+		// its own [start,end). Passing img[start:] handed the encoder a slice
+		// running to the end of the whole multi-frame buffer, which its
+		// exact-size check rejected — so JPEG-LS encoding failed for every
+		// object with more than one frame.
+		jlsFrames := make([][]byte, 0, frames)
+		nearLossless := outTS == transfersyntax.JPEGLSNearLossless.UID
 		for j = 0; j < frames; j++ {
-			offset = j * uint32(cols) * uint32(rows) * uint32(bitsa) / 8
-			if RGB {
-				offset = 3 * offset
-				if err := jpegls.JLSencodeContext(ctx, img[offset:], cols, rows, 3, bitsa, &JPEGData, &JPEGBytes, outTS == transfersyntax.JPEGLSNearLossless.UID); err != nil {
-					return err
-				}
-			} else {
-				if err := jpegls.JLSencodeContext(ctx, img[offset:], cols, rows, 1, bitsa, &JPEGData, &JPEGBytes, outTS == transfersyntax.JPEGLSNearLossless.UID); err != nil {
-					return err
-				}
+			samples, start, end := frameBounds(j, cols, rows, bitsa, RGB)
+			if err := jpegls.JLSencodeContext(ctx, img[start:end], cols, rows, samples, bitsa,
+				&JPEGData, &JPEGBytes, nearLossless); err != nil {
+				return err
 			}
-			index = appendEncapsulatedFrame(obj, index, JPEGData)
+			jlsFrames = append(jlsFrames, JPEGData)
 			JPEGData = nil
 		}
-		index = endEncapsulatedPixelData(obj, index)
+		index = appendEncapsulatedFrames(obj, index, jlsFrames)
 		*i = index
 	case transfersyntax.JPEG2000Lossless.UID:
 		fallthrough
@@ -611,23 +611,28 @@ func compress(ctx context.Context, obj media.DICOMObject, i *int, img []byte, RG
 	case transfersyntax.JPIPHTJ2KReferenced.UID:
 		fallthrough
 	case transfersyntax.JPIPHTJ2KReferencedDeflate.UID:
-		index = beginEncapsulatedPixelData(obj, index)
+		// Encode every frame before mutating the object. The encapsulation
+		// helpers rewrite the pixel-data tag in place, so returning an error
+		// partway through the loop used to leave the object converted to
+		// encapsulated form with no sequence delimiter — neither the original
+		// nor a valid result.
+		jpipFrames := make([][]byte, 0, frames)
 		for j = 0; j < frames; j++ {
-			offset = j * uint32(cols) * uint32(rows) * uint32(bitsa) / 8
-			if RGB {
-				offset = 3 * offset
-				if err := jpip.JPIPencodeContext(ctx, img[offset:], cols, rows, 3, bitsa, &JPEGData, &JPEGBytes, outTS); err != nil {
-					return err
-				}
-			} else {
-				if err := jpip.JPIPencodeContext(ctx, img[offset:], cols, rows, 1, bitsa, &JPEGData, &JPEGBytes, outTS); err != nil {
-					return err
-				}
+			// frameBounds gives a proper [start,end) for this frame. Passing
+			// img[start:] instead handed the encoder a slice running to the end
+			// of the whole multi-frame buffer; the exact-size check in
+			// jpip.purego_backend then rejected it, so JPIP encoding failed for
+			// every object with more than one frame.
+			samples, start, end := frameBounds(j, cols, rows, bitsa, RGB)
+			if err := jpip.JPIPencodeContext(ctx, img[start:end], cols, rows, samples, bitsa,
+				&JPEGData, &JPEGBytes, outTS); err != nil {
+				return err
 			}
-			index = appendEncapsulatedFrame(obj, index, JPEGData)
+			jpipFrames = append(jpipFrames, JPEGData)
 			JPEGData = nil
 		}
-		index = endEncapsulatedPixelData(obj, index)
+		// appendEncapsulatedFrames wraps the begin/end delimiters itself.
+		index = appendEncapsulatedFrames(obj, index, jpipFrames)
 		*i = index
 	case transfersyntax.MPEG2MPML.UID:
 		fallthrough


### PR DESCRIPTION
## Two transfer syntaxes failed on every multi-frame object

Both branches passed `img[offset:]` to the encoder — a slice running to the end of the **whole multi-frame buffer** rather than to the end of the frame. Every other codec uses `frameBounds`, which returns a proper `[start,end)`.

The two encoders that validate input size against the declared dimensions rejected the over-long slice:

```
JPIPHTJ2KReferenced  frames=2,5 -> invalid jpip raw payload size for dimensions
JPEGLSLossless       frames=2,5 -> gojpegls: unsupported JPEG-LS variant
```

`frames=1` worked because `offset` is 0 and the slice happens to be exactly one frame long — which is why this was never noticed.

## Also: a failed encode left the object half-converted

Both branches called `beginEncapsulatedPixelData` **before** their encode loop. That helper rewrites the pixel-data tag in place, so an error partway through left the object converted to encapsulated form with no sequence delimiter — neither the original object nor a valid result.

Frames are now encoded first, and the object is mutated only once every frame has succeeded.

## Why it went unnoticed

The representative round-trip matrix only ever exercises **single-frame** objects — `newMonoRoundTripObject` hard-codes `NumberOfFrames "1"`. The new `multiframe_transcode_test.go` covers **11 transfer syntaxes at 1, 2 and 5 frames**, and reproduces both failures against the unmodified transcoder (verified by stashing the fix).

## Two things that surfaced while writing the test

**The new coverage found the JPEG-LS bug.** Only JPIP was reported by the audit; JPEG-LS has the identical defect and fell out of the added test.

**The test passed alone but failed in a full package run.** `forceCodecBackends` in `dicom_object_test.go` restores every codec to `"passthrough"` on cleanup rather than to its default, leaving the package degraded for whatever runs next. The new test now selects the pure-Go backends explicitly rather than relying on ambient state. Worth fixing that helper separately — it will bite the next test that needs a real backend.

## Deliberately not changed

Five further `img[offset:]` sites remain (JPEG baseline/extended, MPEG, SMPTE2110). They are **latent rather than broken** — those encoders read only their frame's worth and ignore the excess — and the MPEG/SMPTE ones sit behind cgo build tags that cannot be exercised here. I also noticed the 16-bit JPEG path uses `img[offset/2:]`, so the offset arithmetic is not uniform across branches; mechanically rewriting code I cannot test seemed the wrong trade. The new test covers the pure-Go ones and would catch them if any encoder tightened its validation.

Full suite green with a clean cache, `go vet` clean, all three consumers build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)