### PR TITLE
fix(rle): decode all legal segment layouts, and actually compress

### DIFF
--- a/codecs/rle/rle.go
+++ b/codecs/rle/rle.go
@@ -9,20 +9,47 @@ import (
 
 const rleMaxSegments = 15
 
-func encodeLiteralRuns(data []byte) []byte {
+// encodePackBits encodes data as PackBits (PS3.5 Annex G): a replicate run for
+// three or more identical bytes, literal runs otherwise.
+//
+// Only literal runs were emitted before, so "RLE Lossless" never compressed
+// anything -- output was always the input plus one byte per 128, meaning even a
+// uniform frame expanded. The decoder already handled replicate runs, so this
+// is encoder-only and needs no format change.
+func encodePackBits(data []byte) []byte {
 	if len(data) == 0 {
 		return nil
 	}
 
-	out := make([]byte, 0, len(data)+(len(data)/128)+1)
-	for i := 0; i < len(data); {
-		run := len(data) - i
-		if run > 128 {
-			run = 128
+	out := make([]byte, 0, len(data)/2+16)
+	i := 0
+	for i < len(data) {
+		// Measure the run of identical bytes starting at i.
+		runEnd := i + 1
+		for runEnd < len(data) && data[runEnd] == data[i] && runEnd-i < 128 {
+			runEnd++
 		}
-		out = append(out, byte(run-1))
-		out = append(out, data[i:i+run]...)
-		i += run
+		if runEnd-i >= 3 {
+			// Replicate run: count byte is 257-n for n in [2,128].
+			n := runEnd - i
+			out = append(out, byte(257-n), data[i])
+			i = runEnd
+			continue
+		}
+
+		// Literal run: accumulate until a run of three or more appears, or the
+		// 128-byte maximum is reached.
+		litStart := i
+		for i < len(data) && i-litStart < 128 {
+			// Look ahead for a replicate run worth breaking the literal for.
+			if i+2 < len(data) && data[i] == data[i+1] && data[i] == data[i+2] {
+				break
+			}
+			i++
+		}
+		n := i - litStart
+		out = append(out, byte(n-1))
+		out = append(out, data[litStart:i]...)
 	}
 	return out
 }
@@ -66,7 +93,7 @@ func RLEencode(in []byte, rows uint16, cols uint16, bitsAllocated uint16, sample
 
 	encodedSegments := make([][]byte, 0, totalSegments)
 	for _, segment := range rawSegments {
-		encodedSegments = append(encodedSegments, encodeLiteralRuns(segment))
+		encodedSegments = append(encodedSegments, encodePackBits(segment))
 	}
 
 	headerSize := 64
@@ -123,7 +150,12 @@ func readSegment(in []byte, out []byte, segmentOffset uint32, segmentSize uint32
 			inOffset += run
 			outOffset += run
 		case count >= -127:
-			if int(inOffset) >= len(in) || inOffset-segmentOffset > segmentSize {
+			// inOffset indexes the run's value byte, so it must lie strictly
+			// inside the segment: >= not >. With > a segment ending in a bare
+			// replicate-count byte was accepted and took its fill value from the
+			// first byte of the NEXT segment, decoding malformed input to
+			// plausible-looking garbage instead of erroring.
+			if int(inOffset) >= len(in) || inOffset-segmentOffset >= segmentSize {
 				return fmt.Errorf("ERROR, overflow decoding RLE")
 			}
 			run := uint32(-count) + 1
@@ -194,15 +226,9 @@ func RLEdecode(in []byte, out []byte, length uint32, size uint32, photoInt strin
 	}
 
 	offset := decodedPlaneSize
-	switch {
-	case strings.Contains(photoInt, "MONO") && segmentCount == 2:
-		for i := uint32(0); i < decodedPlaneSize; i++ {
-			out[2*i] = temp[i+offset]
-			out[2*i+1] = temp[i]
-		}
-	case strings.Contains(photoInt, "MONO") && segmentCount == 1:
-		copy(out[:size], temp)
-	case photoInt == "YBR_FULL" && segmentCount == 3:
+
+	// YBR_FULL keeps its dedicated path because it also colour-converts to RGB.
+	if photoInt == "YBR_FULL" && segmentCount == 3 {
 		for i := uint32(0); i < decodedPlaneSize; i++ {
 			y := float32(temp[i])
 			cb := float32(temp[i+offset])
@@ -211,15 +237,40 @@ func RLEdecode(in []byte, out []byte, length uint32, size uint32, photoInt strin
 			out[3*i+1] = clampByte(y - 0.344136*(cb-128.0) - 0.714136*(cr-128.0))
 			out[3*i+2] = clampByte(y + 1.772*(cb-128.0))
 		}
-	case photoInt == "RGB" && segmentCount == 3:
-		for i := uint32(0); i < decodedPlaneSize; i++ {
-			out[3*i] = temp[i]
-			out[3*i+1] = temp[i+offset]
-			out[3*i+2] = temp[i+2*offset]
-		}
-	default:
-		return fmt.Errorf("ERROR, format not supported")
+		return nil
 	}
 
+	// Everything else is a planar de-interleave. DICOM RLE (PS3.5 Annex G)
+	// stores samplesPerPixel * bytesPerSample segments, ordered per sample from
+	// the most significant byte down.
+	//
+	// This replaces a fixed set of (photometric, segmentCount) cases that
+	// covered only 1, 2 and 3 segments. 16-bit colour legitimately produces 6,
+	// so the encoder in this package emitted streams its own decoder rejected
+	// with "format not supported", and any conforming 6-segment stream from
+	// another vendor was refused on ingest. PALETTE COLOR was unreachable for
+	// the same reason.
+	samples := uint32(3)
+	if strings.Contains(photoInt, "MONO") || strings.Contains(photoInt, "PALETTE") {
+		samples = 1
+	}
+	if samples > segmentCount || segmentCount%samples != 0 {
+		return fmt.Errorf("ERROR, %d RLE segments is not a multiple of %d samples for %q",
+			segmentCount, samples, photoInt)
+	}
+	bytesPerSample := segmentCount / samples
+	if uint64(decodedPlaneSize)*uint64(segmentCount) > uint64(len(out)) {
+		return fmt.Errorf("ERROR, RLE output buffer too small")
+	}
+	for p := uint32(0); p < decodedPlaneSize; p++ {
+		for s := uint32(0); s < samples; s++ {
+			for b := uint32(0); b < bytesPerSample; b++ {
+				// Segments run most-significant byte first within each sample,
+				// while the output is little-endian.
+				seg := s*bytesPerSample + (bytesPerSample - 1 - b)
+				out[(p*samples+s)*bytesPerSample+b] = temp[seg*decodedPlaneSize+p]
+			}
+		}
+	}
 	return nil
 }

--- a/codecs/rle/rle_test.go
+++ b/codecs/rle/rle_test.go
@@ -93,13 +93,33 @@ func TestRLEdecodeRGB(t *testing.T) {
 	}
 }
 
-func TestRLEdecodeUnsupportedFormat(t *testing.T) {
+// TestRLEdecodePaletteColor: PALETTE COLOR is single-sample, so a one-segment
+// stream decodes as a plain plane. This previously fell to the reassembly
+// switch's default and errored with "format not supported", even though PALETTE
+// COLOR RLE is legal DICOM and common in ultrasound and secondary capture.
+func TestRLEdecodePaletteColor(t *testing.T) {
 	in := buildRLEStream(t, [][]byte{{1, 2, 3, 4}})
 	out := make([]byte, 4)
 
-	err := RLEdecode(in, out, uint32(len(in)), 4, "PALETTE COLOR")
-	if err == nil {
-		t.Fatal("expected error for unsupported format")
+	if err := RLEdecode(in, out, uint32(len(in)), 4, "PALETTE COLOR"); err != nil {
+		t.Fatalf("PALETTE COLOR is single-sample and should decode: %v", err)
+	}
+	for i, want := range []byte{1, 2, 3, 4} {
+		if out[i] != want {
+			t.Fatalf("decoded %v, want [1 2 3 4]", out)
+		}
+	}
+}
+
+// TestRLEdecodeSegmentCountMismatch: a segment count that is not a multiple of
+// the photometric interpretation's sample count is malformed.
+func TestRLEdecodeSegmentCountMismatch(t *testing.T) {
+	// Two segments for a 3-sample photometric interpretation.
+	in := buildRLEStream(t, [][]byte{{1, 2}, {3, 4}})
+	out := make([]byte, 4)
+
+	if err := RLEdecode(in, out, uint32(len(in)), 4, "RGB"); err == nil {
+		t.Fatal("expected an error for 2 segments with 3 samples per pixel")
 	}
 }
 

--- a/codecs/rle/segments_test.go
+++ b/codecs/rle/segments_test.go
@@ -1,0 +1,131 @@
+package rle
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestRoundTripAcrossSegmentLayouts covers every segment count DICOM RLE can
+// produce: samplesPerPixel * bytesPerSample.
+//
+// The decoder previously hard-coded (photometric, segmentCount) cases for 1, 2
+// and 3 segments only. 16-bit colour legitimately produces 6, so RLEencode
+// emitted streams its own decoder rejected with "format not supported", and any
+// conforming 6-segment stream from another vendor was refused on ingest.
+func TestRoundTripAcrossSegmentLayouts(t *testing.T) {
+	const rows, cols = 8, 8
+	cases := []struct {
+		name     string
+		bits     uint16
+		samples  uint16
+		photoInt string
+		wantSegs int
+	}{
+		{"mono 8-bit", 8, 1, "MONOCHROME2", 1},
+		{"mono 16-bit", 16, 1, "MONOCHROME2", 2},
+		{"RGB 8-bit", 8, 3, "RGB", 3},
+		{"RGB 16-bit", 16, 3, "RGB", 6},
+		{"palette 8-bit", 8, 1, "PALETTE COLOR", 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := rows * cols * int(tc.samples) * int(tc.bits/8)
+			raw := make([]byte, n)
+			for i := range raw {
+				raw[i] = byte(i*13 + 7)
+			}
+
+			enc, err := RLEencode(raw, rows, cols, tc.bits, tc.samples)
+			if err != nil {
+				t.Fatalf("RLEencode: %v", err)
+			}
+			if got := int(enc[0]); got != tc.wantSegs {
+				t.Fatalf("header declares %d segments, want %d", got, tc.wantSegs)
+			}
+
+			out := make([]byte, n)
+			if err := RLEdecode(enc, out, uint32(len(enc)), uint32(n), tc.photoInt); err != nil {
+				t.Fatalf("RLEdecode of this package's own %d-segment output: %v", tc.wantSegs, err)
+			}
+			if !bytes.Equal(out, raw) {
+				t.Fatalf("round-trip mismatch for %s", tc.name)
+			}
+		})
+	}
+}
+
+// TestEncodeActuallyCompresses pins the replicate-run fix. The encoder emitted
+// only PackBits literal runs, so output was always the input plus one byte per
+// 128 — meaning even a completely uniform frame expanded, and "RLE Lossless"
+// transcoding always grew the object.
+func TestEncodeActuallyCompresses(t *testing.T) {
+	const rows, cols = 64, 64
+	n := rows * cols
+
+	cases := []struct {
+		name string
+		fill func(i int) byte
+		// Highly compressible input must come out substantially smaller.
+		maxRatio float64
+	}{
+		{"all zero", func(int) byte { return 0 }, 0.10},
+		{"large uniform regions", func(i int) byte { return byte(i / 256) }, 0.20},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := make([]byte, n)
+			for i := range raw {
+				raw[i] = tc.fill(i)
+			}
+			enc, err := RLEencode(raw, rows, cols, 8, 1)
+			if err != nil {
+				t.Fatalf("RLEencode: %v", err)
+			}
+			// Exclude the fixed 64-byte header from the ratio.
+			ratio := float64(len(enc)-64) / float64(n)
+			t.Logf("%d raw -> %d encoded (%.3f of raw, excluding header)", n, len(enc), ratio)
+			if ratio > tc.maxRatio {
+				t.Fatalf("compressible input did not compress: ratio %.3f exceeds %.3f", ratio, tc.maxRatio)
+			}
+
+			// Compression must still be lossless.
+			out := make([]byte, n)
+			if err := RLEdecode(enc, out, uint32(len(enc)), uint32(n), "MONOCHROME2"); err != nil {
+				t.Fatalf("RLEdecode: %v", err)
+			}
+			if !bytes.Equal(out, raw) {
+				t.Fatal("round-trip mismatch after compression")
+			}
+		})
+	}
+}
+
+// TestEncodeIncompressibleStaysBounded guards the replicate-run logic from
+// pathologically expanding data that has no runs.
+func TestEncodeIncompressibleStaysBounded(t *testing.T) {
+	const rows, cols = 64, 64
+	n := rows * cols
+	raw := make([]byte, n)
+	for i := range raw {
+		raw[i] = byte(i*7 + i/3) // no runs of three
+	}
+	enc, err := RLEencode(raw, rows, cols, 8, 1)
+	if err != nil {
+		t.Fatalf("RLEencode: %v", err)
+	}
+	payload := len(enc) - 64
+	// PackBits overhead on incompressible data is one byte per 128.
+	if maxExpected := n + n/128 + 1; payload > maxExpected {
+		t.Fatalf("incompressible input expanded to %d, more than the %d PackBits bound",
+			payload, maxExpected)
+	}
+	out := make([]byte, n)
+	if err := RLEdecode(enc, out, uint32(len(enc)), uint32(n), "MONOCHROME2"); err != nil {
+		t.Fatalf("RLEdecode: %v", err)
+	}
+	if !bytes.Equal(out, raw) {
+		t.Fatal("round-trip mismatch on incompressible data")
+	}
+}


### PR DESCRIPTION
## Three defects, two affecting objects this package produces itself

### 1. The decoder rejected its own 16-bit colour output

Reassembly was a switch over hard-coded `(photometric, segmentCount)` pairs covering **1, 2 and 3 segments only**. DICOM RLE (PS3.5 Annex G) emits `samplesPerPixel × bytesPerSample` segments, so 16-bit colour legitimately produces **6**:

```
RLEdecode of this package's own 6-segment output: ERROR, format not supported
RLEdecode of this package's own 1-segment output: ERROR, format not supported   (PALETTE COLOR)
```

So `RLEencode` wrote streams its own decoder refused, and any conforming 6-segment stream from another vendor was rejected on ingest. PALETTE COLOR was unreachable for the same reason, despite being legal and common in ultrasound and secondary capture.

Replaced with a general planar de-interleave driven by samples and bytes-per-sample. `YBR_FULL` keeps its dedicated path because it also colour-converts.

### 2. `RLEencode` never compressed

Only PackBits **literal** runs were emitted — the replicate run was never generated — so output was always the input plus one byte per 128. Even a completely uniform frame **expanded**, meaning "RLE Lossless" transcoding always *grew* the object.

```
64x64 all-zero frame:  4096 -> 128 bytes  (0.016 of raw, header excluded)
```

The decoder already handled replicate runs, so this is encoder-only and needs no format change. A test pins that incompressible input still stays within the PackBits bound of one byte per 128.

### 3. `readSegment` accepted a truncated replicate run

The bound used `>` where the value byte requires `>=`, so a segment ending in a bare replicate-count byte was accepted and took its fill value from the **first byte of the next segment** — decoding malformed input to plausible-looking garbage rather than erroring. (Contrast the literal branch, which compares `inOffset+run`, one-past-end, where `>` is correct.)

## Testing

Round-trips every segment layout — 1, 2, 3 and 6 segments plus PALETTE COLOR — and verified to fail against the unmodified decoder (output above).

`TestRLEdecodeUnsupportedFormat` asserted the PALETTE COLOR rejection, so it **encoded the bug**. It's replaced by a round-trip test plus a new case covering a segment count that isn't a multiple of the sample count.

Full suite green with a clean cache, `go vet` clean, all three consumers build.

## Not addressed here

The `YBR_FULL` path converts to RGB but **nothing updates PhotometricInterpretation**, so a conforming viewer applies the conversion a second time and the colours come out wrong. Fixing it means deciding which layer owns the tag rewrite — the codec shouldn't really be colour-converting at all — so it needs a call rather than a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)