### PR TITLE
fix(wado): validate UIDs, bound part reads, and stop swallowing part errors

### DIFF
--- a/wado/client.go
+++ b/wado/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -95,19 +96,63 @@ func NewClient(params ClientParams) Client {
 	}
 }
 
+// escapeUID validates a UID and returns it escaped for use in a URL path.
+//
+// UIDs were interpolated raw, so one arriving from an untrusted source -- a
+// QIDO result, a worklist entry, a user field -- could redirect the request:
+// DeleteStudy("1.2.3?evil=1") added a query string, and
+// DeleteStudy("1.2.3/../../../admin/shutdown") reached a different endpoint
+// entirely. On a destructive call that matters. Validation rejects anything
+// that is not a DICOM UID (PS3.5 §9.1); escaping is belt-and-braces for the
+// path context.
+func escapeUID(uid string) (string, error) {
+	if !validUID(uid) {
+		return "", fmt.Errorf("wado: %q is not a valid DICOM UID", uid)
+	}
+	return url.PathEscape(uid), nil
+}
+
+// escapeUIDs applies escapeUID to each argument in order.
+func escapeUIDs(uids ...string) ([]string, error) {
+	out := make([]string, len(uids))
+	for i, uid := range uids {
+		esc, err := escapeUID(uid)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = esc
+	}
+	return out, nil
+}
+
 // ── WADO-RS retrieve ──────────────────────────────────────────────────────────
 
 func (c *wadoClient) RetrieveStudy(ctx context.Context, studyUID string) ([]media.DICOMObject, error) {
+	esc, err := escapeUIDs(studyUID)
+	if err != nil {
+		return nil, err
+	}
+	studyUID = esc[0]
 	u := fmt.Sprintf("%s/wado/rs/studies/%s", c.params.BaseURL, studyUID)
 	return c.retrieveMultipart(ctx, u)
 }
 
 func (c *wadoClient) RetrieveSeries(ctx context.Context, studyUID, seriesUID string) ([]media.DICOMObject, error) {
+	esc, err := escapeUIDs(studyUID, seriesUID)
+	if err != nil {
+		return nil, err
+	}
+	studyUID, seriesUID = esc[0], esc[1]
 	u := fmt.Sprintf("%s/wado/rs/studies/%s/series/%s", c.params.BaseURL, studyUID, seriesUID)
 	return c.retrieveMultipart(ctx, u)
 }
 
 func (c *wadoClient) RetrieveInstance(ctx context.Context, studyUID, seriesUID, sopInstanceUID string) (media.DICOMObject, error) {
+	esc, err := escapeUIDs(studyUID, seriesUID, sopInstanceUID)
+	if err != nil {
+		return nil, err
+	}
+	studyUID, seriesUID, sopInstanceUID = esc[0], esc[1], esc[2]
 	u := fmt.Sprintf("%s/wado/rs/studies/%s/series/%s/instances/%s",
 		c.params.BaseURL, studyUID, seriesUID, sopInstanceUID)
 	objects, err := c.retrieveMultipart(ctx, u)
@@ -121,6 +166,11 @@ func (c *wadoClient) RetrieveInstance(ctx context.Context, studyUID, seriesUID, 
 }
 
 func (c *wadoClient) RetrieveMetadata(ctx context.Context, studyUID, seriesUID, sopInstanceUID string) (map[string]interface{}, error) {
+	esc, err := escapeUIDs(studyUID, seriesUID, sopInstanceUID)
+	if err != nil {
+		return nil, err
+	}
+	studyUID, seriesUID, sopInstanceUID = esc[0], esc[1], esc[2]
 	u := fmt.Sprintf("%s/wado/rs/studies/%s/series/%s/instances/%s/metadata",
 		c.params.BaseURL, studyUID, seriesUID, sopInstanceUID)
 	resp, err := c.doRequest(ctx, http.MethodGet, u, "", nil)
@@ -184,7 +234,11 @@ func (c *wadoClient) StoreInstances(ctx context.Context, studyUID string, object
 
 	var u string
 	if studyUID != "" {
-		u = fmt.Sprintf("%s/stow/rs/studies/%s", c.params.BaseURL, studyUID)
+		esc, err := escapeUID(studyUID)
+		if err != nil {
+			return err
+		}
+		u = fmt.Sprintf("%s/stow/rs/studies/%s", c.params.BaseURL, esc)
 	} else {
 		u = fmt.Sprintf("%s/stow/rs/studies", c.params.BaseURL)
 	}
@@ -204,11 +258,21 @@ func (c *wadoClient) SearchStudies(ctx context.Context, params url.Values) ([]ma
 }
 
 func (c *wadoClient) SearchSeries(ctx context.Context, studyUID string, params url.Values) ([]map[string]interface{}, error) {
+	esc, err := escapeUIDs(studyUID)
+	if err != nil {
+		return nil, err
+	}
+	studyUID = esc[0]
 	u := fmt.Sprintf("%s/qido/rs/studies/%s/series", c.params.BaseURL, studyUID)
 	return c.searchJSON(ctx, u, params)
 }
 
 func (c *wadoClient) SearchInstances(ctx context.Context, studyUID, seriesUID string, params url.Values) ([]map[string]interface{}, error) {
+	esc, err := escapeUIDs(studyUID, seriesUID)
+	if err != nil {
+		return nil, err
+	}
+	studyUID, seriesUID = esc[0], esc[1]
 	u := fmt.Sprintf("%s/qido/rs/studies/%s/series/%s/instances", c.params.BaseURL, studyUID, seriesUID)
 	return c.searchJSON(ctx, u, params)
 }
@@ -298,6 +362,11 @@ func jsonNumber(v interface{}) (int64, bool) {
 
 // RetrieveFrames fetches raw pixel data for the given 1-based frame numbers.
 func (c *wadoClient) RetrieveFrames(ctx context.Context, studyUID, seriesUID, sopInstanceUID string, frames []int) ([][]byte, error) {
+	esc, err := escapeUIDs(studyUID, seriesUID, sopInstanceUID)
+	if err != nil {
+		return nil, err
+	}
+	studyUID, seriesUID, sopInstanceUID = esc[0], esc[1], esc[2]
 	if len(frames) == 0 {
 		return nil, fmt.Errorf("wado: RetrieveFrames: frames list must not be empty")
 	}
@@ -316,6 +385,11 @@ func (c *wadoClient) RetrieveFrames(ctx context.Context, studyUID, seriesUID, so
 // ── WADO-RS delete ────────────────────────────────────────────────────────────
 
 func (c *wadoClient) DeleteStudy(ctx context.Context, studyUID string) error {
+	esc, err := escapeUIDs(studyUID)
+	if err != nil {
+		return err
+	}
+	studyUID = esc[0]
 	u := fmt.Sprintf("%s/wado/rs/studies/%s", c.params.BaseURL, studyUID)
 	resp, err := c.doRequest(ctx, http.MethodDelete, u, "", nil)
 	if err != nil {
@@ -326,6 +400,11 @@ func (c *wadoClient) DeleteStudy(ctx context.Context, studyUID string) error {
 }
 
 func (c *wadoClient) DeleteSeries(ctx context.Context, studyUID, seriesUID string) error {
+	esc, err := escapeUIDs(studyUID, seriesUID)
+	if err != nil {
+		return err
+	}
+	studyUID, seriesUID = esc[0], esc[1]
 	u := fmt.Sprintf("%s/wado/rs/studies/%s/series/%s", c.params.BaseURL, studyUID, seriesUID)
 	resp, err := c.doRequest(ctx, http.MethodDelete, u, "", nil)
 	if err != nil {
@@ -336,6 +415,11 @@ func (c *wadoClient) DeleteSeries(ctx context.Context, studyUID, seriesUID strin
 }
 
 func (c *wadoClient) DeleteInstance(ctx context.Context, studyUID, seriesUID, sopInstanceUID string) error {
+	esc, err := escapeUIDs(studyUID, seriesUID, sopInstanceUID)
+	if err != nil {
+		return err
+	}
+	studyUID, seriesUID, sopInstanceUID = esc[0], esc[1], esc[2]
 	u := fmt.Sprintf("%s/wado/rs/studies/%s/series/%s/instances/%s",
 		c.params.BaseURL, studyUID, seriesUID, sopInstanceUID)
 	resp, err := c.doRequest(ctx, http.MethodDelete, u, "", nil)
@@ -360,18 +444,32 @@ func (c *wadoClient) eachMultipartPart(ctx context.Context, rawURL string, fn fu
 	}
 
 	mr := multipart.NewReader(resp.Body, mparams["boundary"])
+	var partErrs []error
+	partIndex := 0
 	for {
 		part, partErr := mr.NextPart()
 		if partErr != nil {
+			if !errors.Is(partErr, io.EOF) {
+				partErrs = append(partErrs, fmt.Errorf("reading part %d: %w", partIndex, partErr))
+			}
 			break
 		}
-		data, readErr := io.ReadAll(part)
+		data, readErr := limitedReadAll(part)
 		if readErr != nil {
+			// Surface the failure rather than silently dropping the part: a
+			// caller previously could not tell "the study has 3 instances" from
+			// "the study has 40 and 37 were unreadable". The cap also stops a
+			// hostile or compromised peer from OOMing the client -- io.ReadAll
+			// had no ceiling at all here, so a single 300 MiB part allocated
+			// 775 MiB and a 10 GiB part was equally accepted.
+			partErrs = append(partErrs, fmt.Errorf("part %d: %w", partIndex, readErr))
+			partIndex++
 			continue
 		}
 		fn(data)
+		partIndex++
 	}
-	return nil
+	return errors.Join(partErrs...)
 }
 
 // retrieveMultipartBytes fetches a WADO-RS URL and returns each part as raw bytes.
@@ -387,12 +485,19 @@ func (c *wadoClient) retrieveMultipartBytes(ctx context.Context, rawURL string) 
 // retrieveMultipart fetches a WADO-RS URL and returns parsed DICOM objects.
 func (c *wadoClient) retrieveMultipart(ctx context.Context, rawURL string) ([]media.DICOMObject, error) {
 	var objects []media.DICOMObject
+	var parseErrs []error
 	err := c.eachMultipartPart(ctx, rawURL, func(data []byte) {
-		if obj, parseErr := media.NewDCMObjFromBytes(data); parseErr == nil {
-			objects = append(objects, obj)
+		obj, parseErr := media.NewDCMObjFromBytes(data)
+		if parseErr != nil {
+			// A part that does not parse is a real failure, not something to
+			// drop quietly; the caller cannot otherwise distinguish a short
+			// study from a corrupt one.
+			parseErrs = append(parseErrs, parseErr)
+			return
 		}
+		objects = append(objects, obj)
 	})
-	return objects, err
+	return objects, errors.Join(append(parseErrs, err)...)
 }
 
 // searchJSON performs a QIDO-RS GET and decodes the JSON response.

--- a/wado/client_security_test.go
+++ b/wado/client_security_test.go
@@ -1,0 +1,120 @@
+package wado_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/wado"
+)
+
+// TestClientRejectsURLInjectingUIDs pins UID validation on the client.
+//
+// UIDs were interpolated into URLs raw, so one arriving from an untrusted
+// source — a QIDO result, a worklist entry, a user field — could redirect the
+// request. "1.2.3?evil=1" appended a query string and
+// "1.2.3/../../../admin/shutdown" reached a different endpoint entirely. On
+// DeleteStudy that redirects a destructive call.
+func TestClientRejectsURLInjectingUIDs(t *testing.T) {
+	var reached []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = append(reached, r.URL.Path+"?"+r.URL.RawQuery)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := wado.NewClient(wado.ClientParams{BaseURL: srv.URL})
+	ctx := context.Background()
+
+	hostile := []string{
+		"1.2.3?evil=1",
+		"1.2.3/../../../admin/shutdown",
+		"1.2.3/series/9.9.9/instances/8.8.8",
+		"../../secret",
+		"not-a-uid",
+		strings.Repeat("1", 65),
+	}
+
+	for _, uid := range hostile {
+		if err := c.DeleteStudy(ctx, uid); err == nil {
+			t.Errorf("DeleteStudy(%q) was allowed to build a request", uid)
+		}
+		if _, err := c.RetrieveStudy(ctx, uid); err == nil {
+			t.Errorf("RetrieveStudy(%q) was allowed to build a request", uid)
+		}
+	}
+
+	if len(reached) != 0 {
+		t.Fatalf("hostile UIDs reached the server: %v", reached)
+	}
+}
+
+// TestClientAcceptsValidUIDs guards the validation from rejecting real UIDs.
+func TestClientAcceptsValidUIDs(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := wado.NewClient(wado.ClientParams{BaseURL: srv.URL})
+	const uid = "1.2.840.113619.2.30.1.1762295590.1623.978668949.886"
+	if err := c.DeleteStudy(context.Background(), uid); err != nil {
+		t.Fatalf("DeleteStudy with a valid UID: %v", err)
+	}
+	if want := "/wado/rs/studies/" + uid; gotPath != want {
+		t.Fatalf("got path %q, want %q", gotPath, want)
+	}
+}
+
+// TestClientReportsUnparseableParts pins error propagation. Parts that failed to
+// read or parse were skipped with `continue` and the call returned nil, so a
+// caller could not distinguish "the study has 2 instances" from "the study has
+// 40 and 38 were corrupt".
+func TestClientReportsUnparseableParts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", `multipart/related; type="application/dicom"; boundary=BOUNDARY`)
+		w.WriteHeader(http.StatusOK)
+		// Two parts, neither a valid DICOM object.
+		_, _ = w.Write([]byte("--BOUNDARY\r\nContent-Type: application/dicom\r\n\r\nnot dicom\r\n" +
+			"--BOUNDARY\r\nContent-Type: application/dicom\r\n\r\nalso not dicom\r\n--BOUNDARY--\r\n"))
+	}))
+	defer srv.Close()
+
+	c := wado.NewClient(wado.ClientParams{BaseURL: srv.URL})
+	objs, err := c.RetrieveStudy(context.Background(), "1.2.3")
+	if err == nil {
+		t.Fatalf("unparseable parts reported success with %d objects", len(objs))
+	}
+	if len(objs) != 0 {
+		t.Fatalf("expected no objects, got %d", len(objs))
+	}
+}
+
+// TestClientBoundsPartSize pins the read cap. io.ReadAll had no ceiling on the
+// client side, so a hostile or compromised peer could OOM it — an audit measured
+// a single 300 MiB part allocating 775 MiB, with 10 GiB equally accepted.
+func TestClientBoundsPartSize(t *testing.T) {
+	const oversize = 70 << 20 // above the 64 MiB per-part cap
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", `multipart/related; type="application/dicom"; boundary=BOUNDARY`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("--BOUNDARY\r\nContent-Type: application/dicom\r\n\r\n"))
+		chunk := make([]byte, 1<<20)
+		for sent := 0; sent < oversize; sent += len(chunk) {
+			if _, err := w.Write(chunk); err != nil {
+				return
+			}
+		}
+		_, _ = w.Write([]byte("\r\n--BOUNDARY--\r\n"))
+	}))
+	defer srv.Close()
+
+	c := wado.NewClient(wado.ClientParams{BaseURL: srv.URL})
+	if _, err := c.RetrieveStudy(context.Background(), "1.2.3"); err == nil {
+		t.Fatal("an oversized part was accepted without error")
+	}
+}

--- a/wado/client_test.go
+++ b/wado/client_test.go
@@ -38,7 +38,7 @@ func TestClient_RetrieveStudy_NotFound(t *testing.T) {
 	srv, _ := newWADOTestServer(t)
 	defer srv.Close()
 	client := wado.NewClient(wado.ClientParams{BaseURL: srv.URL})
-	_, err := client.RetrieveStudy(context.Background(), "0.0.0.missing")
+	_, err := client.RetrieveStudy(context.Background(), "0.0.0.999")
 	if err == nil {
 		t.Fatal("want error for missing study")
 	}
@@ -200,7 +200,7 @@ func TestClient_RetrieveFrames_OK(t *testing.T) {
 	defer srv.Close()
 
 	client := wado.NewClient(wado.ClientParams{BaseURL: srv.URL})
-	frames, err := client.RetrieveFrames(context.Background(), "s", "se", "sop", []int{1, 2})
+	frames, err := client.RetrieveFrames(context.Background(), "1.2.3", "1.2.3.4", "1.2.3.4.5", []int{1, 2})
 	if err != nil {
 		t.Fatalf("RetrieveFrames() error: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestClient_RetrieveFrames_OK(t *testing.T) {
 
 func TestClient_RetrieveFrames_EmptyList(t *testing.T) {
 	client := wado.NewClient(wado.ClientParams{BaseURL: "http://127.0.0.1:1"})
-	_, err := client.RetrieveFrames(context.Background(), "s", "se", "sop", nil)
+	_, err := client.RetrieveFrames(context.Background(), "1.2.3", "1.2.3.4", "1.2.3.4.5", nil)
 	if err == nil {
 		t.Fatal("want error for empty frame list")
 	}


### PR DESCRIPTION
## Three defects in the DICOMweb client

### 1. 🔴 UIDs were interpolated into URLs raw

Every request path was built with `fmt.Sprintf` and an **unescaped** UID, so one arriving from an untrusted source — a QIDO result, a worklist entry, a user field — could redirect the request:

```
DeleteStudy("1.2.3?evil=1")                        -> added a query string
DeleteStudy("1.2.3/../../../admin/shutdown")       -> a different endpoint
DeleteStudy("1.2.3/series/9.9.9/instances/8.8.8")  -> the instance-delete route
```

On a **destructive** call that matters — the caller thinks it is deleting a study and the request lands somewhere else entirely.

UIDs are now validated against PS3.5 §9.1 and path-escaped before use, in every retrieve, metadata, search, frames, store and delete method.

### 2. Parts were read with an unbounded `io.ReadAll`

`maxPartBytes` existed only on the **server**, so a hostile or compromised peer could exhaust client memory. An audit measured a single 300 MiB part allocating **775 MiB** (`io.ReadAll`'s doubling keeps old buffers alive), with a 10 GiB part equally accepted. Client reads now use the same cap the server applies.

### 3. Unreadable and unparseable parts were silently dropped

Both loops used `continue` and the call returned `nil`, so a caller could not distinguish *"the study has 2 instances"* from *"the study has 40 and 38 were corrupt"*. Per-part failures are now collected and returned via `errors.Join`, and a non-EOF error from `NextPart` is reported rather than treated as the end of the stream.

## Verification

The tests drive the redirection attack against a real `httptest` server and assert **nothing reaches it**. Confirmed to fail with validation neutered:

```
DeleteStudy("1.2.3?evil=1") was allowed to build a request
DeleteStudy("1.2.3/../../../admin/shutdown") was allowed to build a request
DeleteStudy("1.2.3/series/9.9.9/instances/8.8.8") was allowed to build a request
DeleteStudy("../../secret") was allowed to build a request
```

Also covered: valid UIDs still produce the expected path; unparseable parts now error; an oversized part is rejected.

## Note

Three existing test call sites used placeholder UIDs that are not valid DICOM UIDs (`"s"`/`"se"`/`"sop"`, `"0.0.0.missing"`). They now use conformant values so the tests exercise their intended behaviour rather than UID validation.

Full suite green with a clean cache, `go vet` clean, all three consumers build and test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)