### PR TITLE
fix(wado): reject STOW instances from a different study; fix codec backend leak in tests

### DIFF
--- a/media/dicom_object_test.go
+++ b/media/dicom_object_test.go
@@ -605,16 +605,22 @@ func forceCodecBackends(t *testing.T, cfg codecs.BackendConfig) {
 	}
 
 	t.Cleanup(func() {
+		// Restore the pure-Go defaults, not "passthrough". Restoring to
+		// passthrough left every codec unable to encode or decode for whatever
+		// test ran next, which is a leak across tests: a later test would fail
+		// with "no encode backend available" while passing in isolation.
+		// MPEG and SMPTE2110 have no pure-Go implementation, so passthrough is
+		// their default.
 		if err := codecs.UseBackends(codecs.BackendConfig{
-			JPEG:      "passthrough",
-			JPEGLS:    "passthrough",
-			JPEG2000:  "passthrough",
-			JPEGXL:    "passthrough",
+			JPEG:      "gojpeg",
+			JPEGLS:    "gojpegls",
+			JPEG2000:  "gojpeg2000",
+			JPEGXL:    "gojpegxl",
 			MPEG:      "passthrough",
-			JPIP:      "passthrough",
+			JPIP:      "gojpip",
 			SMPTE2110: "passthrough",
 		}); err != nil {
-			t.Fatalf("failed to restore passthrough codec backends: %v", err)
+			t.Fatalf("failed to restore default codec backends: %v", err)
 		}
 	})
 }

--- a/wado/client_test.go
+++ b/wado/client_test.go
@@ -110,7 +110,7 @@ func TestClient_StoreInstances_WithStudyUID(t *testing.T) {
 	obj := loadSampleDICOM(t)
 
 	client := wado.NewClient(wado.ClientParams{BaseURL: srv.URL})
-	err := client.StoreInstances(context.Background(), "1.2.3", []media.DICOMObject{obj})
+	err := client.StoreInstances(context.Background(), "1.3.46.670589.11.8410.6.132672291010455276", []media.DICOMObject{obj})
 	if err != nil {
 		t.Fatalf("StoreInstances() error: %v", err)
 	}

--- a/wado/security_test.go
+++ b/wado/security_test.go
@@ -142,3 +142,29 @@ func TestStoreRejectsEmptyBody(t *testing.T) {
 		t.Fatalf("an empty upload returned %d: %s", rec.Code, rec.Body.String())
 	}
 }
+
+// TestStoreRejectsInstanceFromDifferentStudy pins the study-scoped STOW check.
+//
+// The {studyUID} path segment was ignored entirely, so POSTing to
+// /stow/rs/studies/{A} happily stored instances belonging to study B. Beyond the
+// PS3.18 §10.5 conformance point, any deployment that authorises STOW per-study
+// had that authorisation bypassed: the path said one study while the payload
+// wrote another.
+func TestStoreRejectsInstanceFromDifferentStudy(t *testing.T) {
+	h, store := newTestHandler(t)
+	body, ct := buildMultipartDICOMBody(t, loadSampleDICOM(t))
+
+	// A syntactically valid UID that is not the instance's study.
+	req := httptest.NewRequest("POST", "/stow/rs/studies/9.9.9.999", body)
+	req.Header.Set("Content-Type", ct)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code < 400 {
+		t.Fatalf("an instance from a different study was accepted with %d: %s",
+			rec.Code, rec.Body.String())
+	}
+	if len(store.stored) != 0 {
+		t.Fatalf("expected nothing stored, got %d", len(store.stored))
+	}
+}

--- a/wado/server.go
+++ b/wado/server.go
@@ -291,6 +291,11 @@ func (s *wadoServer) retrieveFrames(w http.ResponseWriter, r *http.Request) {
 // ── STOW-RS store handler ─────────────────────────────────────────────────────
 
 func (s *wadoServer) storeInstances(w http.ResponseWriter, r *http.Request) {
+	// The study-scoped route carries a UID; the generic route does not.
+	targetStudyUID := r.PathValue("studyUID")
+	if targetStudyUID != "" && !requireUIDs(w, targetStudyUID) {
+		return
+	}
 	mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	if err != nil || !strings.HasPrefix(mediaType, "multipart/") {
 		http.Error(w, "expected multipart/related content", http.StatusBadRequest)
@@ -334,6 +339,20 @@ func (s *wadoServer) storeInstances(w http.ResponseWriter, r *http.Request) {
 			slog.Warn("STOW-RS: failed to parse DICOM part", "err", parseErr)
 			failed++
 			continue
+		}
+		// PS3.18 §10.5: when the request targets a specific study, an instance
+		// belonging to a different one must be rejected. The path segment was
+		// previously ignored entirely, so POSTing to /stow/rs/studies/{A} happily
+		// stored instances belonging to study B — and any deployment that
+		// authorises STOW per-study had that authorisation bypassed, because the
+		// path said one study while the payload wrote another.
+		if targetStudyUID != "" {
+			if got := obj.GetString(tags.StudyInstanceUID); got != targetStudyUID {
+				slog.Warn("STOW-RS: instance belongs to a different study",
+					"want", targetStudyUID, "got", got)
+				failed++
+				continue
+			}
 		}
 		objects = append(objects, obj)
 	}

--- a/wado/server_test.go
+++ b/wado/server_test.go
@@ -215,7 +215,9 @@ func TestStoreInstances_WithStudyUID(t *testing.T) {
 	h, store := newTestHandler(t)
 	body, ct := buildMultipartDICOMBody(t, loadSampleDICOM(t))
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/stow/rs/studies/1.2.3", body)
+	// The path study UID must match the instance's StudyInstanceUID; PS3.18
+	// §10.5 requires rejecting a mismatch.
+	req := httptest.NewRequest("POST", "/stow/rs/studies/1.3.46.670589.11.8410.6.132672291010455276", body)
 	req.Header.Set("Content-Type", ct)
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {


### PR DESCRIPTION
## 1. STOW-RS ignored the `{studyUID}` path segment

`storeInstances` never read `r.PathValue("studyUID")`, so POSTing to `/stow/rs/studies/{A}` happily stored instances belonging to study **B**.

Beyond the PS3.18 §10.5 conformance point, this is an **authorisation bypass** in any deployment that grants STOW per-study: the path said one study while the payload wrote another.

Instances whose `StudyInstanceUID` differs from the path are now counted as failures, so the existing partial/total-failure statuses apply — **409** when nothing else stored, **202** when some instances did.

Verified by removing the check — the mismatched instance came back **200 with the SOP instance listed in the ReferencedSOPSequence**, as though it had been archived:

```
an instance from a different study was accepted with 200:
{"00081199":{"Value":[{"00081150":...,"00081155":["1.3.46.670589.11.8410.9.1326...]}]}}
```

## 2. `forceCodecBackends` restored `"passthrough"` instead of the defaults

The `t.Cleanup` in `dicom_object_test.go` reset every codec to `"passthrough"`, which **cannot encode or decode**. That left the whole `media` package degraded for whatever test ran next — a later test would fail with `no encode backend available` while passing in isolation.

This is not hypothetical: it cost real diagnosis time when the multi-frame transcode tests hit it in #45, and I worked around it there rather than fixing the cause.

Cleanup now restores the pure-Go defaults (`gojpeg`, `gojpegls`, `gojpeg2000`, `gojpegxl`, `gojpip`). MPEG and SMPTE2110 have no pure-Go implementation, so `passthrough` is correct for those.

Confirmed by **removing the workaround** from the multi-frame test — the package passes without it now.

## Note

Two STOW test call sites paired a fixture object with an unrelated path study UID, which is exactly the mismatch now rejected. They use the instance's own `StudyInstanceUID`.

Full suite green with a clean cache, `go vet` clean, all three consumers build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)