### PR TITLE
fix(network): bound the DIMSE message accumulated across P-DATA fragments

### DIFF
--- a/network/max_message_test.go
+++ b/network/max_message_test.go
@@ -1,0 +1,121 @@
+package network
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// pdataPDU builds one P-DATA-TF PDU carrying a single PDV of payload bytes.
+// last controls the PDV's last-fragment bit; a peer that never sets it makes
+// NextPDU keep accumulating.
+func pdataPDU(pcid byte, payload []byte, last bool) []byte {
+	msgHeader := byte(0x00) // data, not last
+	if last {
+		msgHeader = PDVLastFragment
+	}
+	pdvLen := uint32(len(payload)) + 2 // PCID + msgHeader
+	pduLen := pdvLen + 4               // + the PDV length field
+
+	out := make([]byte, 0, int(pduLen)+6)
+	out = append(out, byte(0x04), 0x00) // P-DATA-TF, reserved
+	var b4 [4]byte
+	binary.BigEndian.PutUint32(b4[:], pduLen)
+	out = append(out, b4[:]...)
+	binary.BigEndian.PutUint32(b4[:], pdvLen)
+	out = append(out, b4[:]...)
+	out = append(out, pcid, msgHeader)
+	return append(out, payload...)
+}
+
+// TestAccumulatedMessageIsBounded pins the ceiling on one DIMSE message.
+//
+// maxIncomingPDULength caps an individual PDU at 16 MiB, but nothing bounded the
+// sum across fragments: NextPDU loops while the last-fragment bit is clear,
+// appending every PDV into Pdata.Buffer, so a peer that simply never sets that
+// bit grows the buffer without limit.
+func TestAccumulatedMessageIsBounded(t *testing.T) {
+	const (
+		limit     = 64 << 10 // small ceiling so the test stays fast
+		fragment  = 4 << 10
+		fragments = 64 // 256 KiB total, four times the ceiling
+	)
+
+	var wire bytes.Buffer
+	payload := make([]byte, fragment)
+	for i := 0; i < fragments; i++ {
+		// Never set the last-fragment bit: the accumulation must stop anyway.
+		wire.Write(pdataPDU(1, payload, false))
+	}
+
+	pdu := NewPDUService(WithMaxMessageSize(limit)).(*pduService)
+	r := bufio.NewReader(bytes.NewReader(wire.Bytes()))
+	w := bufio.NewWriter(&bytes.Buffer{})
+	pdu.SetConn(bufio.NewReadWriter(r, w))
+	pdu.negotiated = true
+
+	obj, err := pdu.NextPDU()
+	if err == nil {
+		t.Fatalf("a peer that never ends the message was allowed to accumulate "+
+			"%d bytes (obj=%v)", pdu.Pdata.Buffer.GetSize(), obj)
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected a size-limit error, got %v", err)
+	}
+	// The buffer must not have grown far past the ceiling before erroring: one
+	// fragment of overshoot is expected, not the whole stream.
+	if got := pdu.Pdata.Buffer.GetSize(); got > limit+fragment {
+		t.Fatalf("accumulated %d bytes against a %d-byte ceiling", got, limit)
+	}
+}
+
+// TestMessageUnderLimitStillAssembles guards the ceiling from breaking ordinary
+// multi-fragment messages, which is the normal case for any real instance.
+func TestMessageUnderLimitStillAssembles(t *testing.T) {
+	const fragment = 1 << 10
+
+	var wire bytes.Buffer
+	payload := make([]byte, fragment)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	// Three continuation fragments then a terminating one.
+	for i := 0; i < 3; i++ {
+		wire.Write(pdataPDU(1, payload, false))
+	}
+	wire.Write(pdataPDU(1, payload, true))
+
+	pdu := NewPDUService(WithMaxMessageSize(1 << 20)).(*pduService)
+	r := bufio.NewReader(bytes.NewReader(wire.Bytes()))
+	w := bufio.NewWriter(&bytes.Buffer{})
+	pdu.SetConn(bufio.NewReadWriter(r, w))
+	pdu.negotiated = true
+
+	// The assembled payload is not a valid DIMSE command, so NextPDU reports a
+	// parse failure — but it must not be a size-limit rejection, and all four
+	// fragments must have been accumulated first.
+	_, err := pdu.NextPDU()
+	if err != nil && strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("a 4 KiB message was rejected against a 1 MiB ceiling: %v", err)
+	}
+	if got := pdu.Pdata.Buffer.GetSize(); got != 4*fragment {
+		t.Fatalf("accumulated %d bytes, want %d — fragments were dropped", got, 4*fragment)
+	}
+}
+
+// TestDefaultMessageLimitApplies confirms a service built without the option
+// still carries a ceiling.
+func TestDefaultMessageLimitApplies(t *testing.T) {
+	pdu := NewPDUService().(*pduService)
+	if pdu.maxMessageBytes != defaultMaxMessageBytes {
+		t.Fatalf("default ceiling is %d, want %d", pdu.maxMessageBytes, defaultMaxMessageBytes)
+	}
+	// A non-positive override restores the default rather than disabling it.
+	pdu2 := NewPDUService(WithMaxMessageSize(0)).(*pduService)
+	if pdu2.maxMessageBytes != defaultMaxMessageBytes {
+		t.Fatalf("WithMaxMessageSize(0) left %d, want the default %d",
+			pdu2.maxMessageBytes, defaultMaxMessageBytes)
+	}
+}

--- a/network/pdu_service.go
+++ b/network/pdu_service.go
@@ -99,6 +99,18 @@ func WithImplementationClass(uid, version string) PDUServiceOption {
 	}
 }
 
+// WithMaxMessageSize overrides the ceiling on one DIMSE message accumulated
+// across P-DATA fragments. A non-positive value restores the default
+// (defaultMaxMessageBytes).
+func WithMaxMessageSize(n int) PDUServiceOption {
+	return func(p *pduService) {
+		if n <= 0 {
+			n = defaultMaxMessageBytes
+		}
+		p.maxMessageBytes = n
+	}
+}
+
 // WithLogger sets the structured logger used for PDU-level events on this
 // connection. By default the library logs through slog.Default(). Pass a logger
 // derived with per-association attributes to correlate concurrent associations.
@@ -128,6 +140,9 @@ type pduService struct {
 	implClassUID                 string
 	implVersion                  string
 	logger                       *slog.Logger
+	// maxMessageBytes bounds the total size of one DIMSE message accumulated
+	// across P-DATA fragments. See defaultMaxMessageBytes.
+	maxMessageBytes int
 	// negotiated records that an association has been established on this
 	// connection. PS3.8 §9.3.1 permits exactly one A-ASSOCIATE-RQ per
 	// association; without this guard the same connection can renegotiate
@@ -147,13 +162,14 @@ type pduService struct {
 // configure non-default behaviour (e.g. WithImplementationClass).
 func NewPDUService(opts ...PDUServiceOption) PDUService {
 	p := &pduService{
-		buf:       media.NewDICOMBuffer(),
-		AssocRQ:   newAssociationRequest(),
-		AssocAC:   newAssociationAccept(),
-		AssocRJ:   NewAssociationReject(),
-		ReleaseRQ: NewReleaseRequest(),
-		ReleaseRP: NewReleaseResponse(),
-		AbortRQ:   NewAbortRequest(),
+		maxMessageBytes: defaultMaxMessageBytes,
+		buf:             media.NewDICOMBuffer(),
+		AssocRQ:         newAssociationRequest(),
+		AssocAC:         newAssociationAccept(),
+		AssocRJ:         NewAssociationReject(),
+		ReleaseRQ:       NewReleaseRequest(),
+		ReleaseRP:       NewReleaseResponse(),
+		AbortRQ:         NewAbortRequest(),
 	}
 	p.SetLogger(nil)
 	for _, opt := range opts {
@@ -205,6 +221,19 @@ const maxPduLength uint32 = 16384
 // a multi-gigabyte allocation (DoS). 16 MiB is orders of magnitude above any
 // conformant PDU yet trivially bounded.
 const maxIncomingPDULength uint32 = 16 << 20
+
+// defaultMaxMessageBytes bounds one DIMSE message accumulated across P-DATA
+// fragments.
+//
+// maxIncomingPDULength caps an INDIVIDUAL PDU at 16 MiB, but nothing bounded the
+// sum: NextPDU loops while the last-fragment bit is clear, appending every PDV
+// into Pdata.Buffer, so a peer that simply never sets that bit grows the buffer
+// without limit. 1 GiB is far above any real DIMSE message (a large multi-frame
+// instance is tens of MB) while keeping a hostile peer bounded.
+//
+// Override with WithMaxMessageSize when an archive genuinely handles larger
+// objects.
+const defaultMaxMessageBytes = 1 << 30
 
 const releaseHandshakeTimeout = 5 * time.Second
 
@@ -573,6 +602,13 @@ func (pdu *pduService) NextPDU() (command media.DICOMObject, err error) {
 			pdu.buf.SetPosition(1)
 			if err := pdu.Pdata.ReadDynamic(pdu.buf); err != nil {
 				return nil, err
+			}
+			// Bound the accumulated message, not just each PDU. Without this a
+			// peer that never sets the last-fragment bit grows Pdata.Buffer
+			// without limit.
+			if limit := pdu.maxMessageBytes; limit > 0 && pdu.Pdata.Buffer.GetSize() > limit {
+				return nil, pdu.abortWithError(fmt.Sprintf(
+					"DIMSE message exceeds %d bytes", limit))
 			}
 			if pdu.Pdata.MsgStatus > 0 {
 				DCO := media.NewEmptyDCMObj()


### PR DESCRIPTION
## The per-PDU cap did nothing to stop this

`maxIncomingPDULength` caps an **individual** PDU at 16 MiB, but nothing bounded the **sum**. `NextPDU` loops while the PDV last-fragment bit is clear, appending each PDV into `Pdata.Buffer` — so a peer that simply **never sets that bit** grows the buffer without limit.

No authentication required, and the existing per-PDU ceiling is irrelevant to it.

## Fix

A ceiling on the accumulated message, checked after each fragment, with A-ABORT on breach.

`defaultMaxMessageBytes` is **1 GiB** — far above any real DIMSE message (a large multi-frame instance is tens of MB) while keeping a hostile peer bounded. `WithMaxMessageSize` overrides it for archives that genuinely handle larger objects; a non-positive value restores the default rather than disabling the bound, so the ceiling can't be switched off by accident.

## Tests

Drive the actual attack — 64 fragments with the last-fragment bit **never** set — and assert both that it is rejected *and* that the buffer does not grow far past the ceiling before erroring (one fragment of overshoot, not the whole stream). Verified to fail with the bound removed.

A companion test pins that an ordinary multi-fragment message still assembles from **all four** of its fragments, since that is the normal case for any real instance — a ceiling that broke fragment reassembly would be worse than the bug.

A third confirms the default applies to a service built without the option, and that `WithMaxMessageSize(0)` restores it.

## Testing
- Full suite green with a clean cache; `go vet` clean
- `FuzzReadIncomingPDU` and `FuzzPDataTFReadDynamic` clean
- All three consumers build

This closes the last of the unbounded-allocation findings on the wire path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)