### PR TITLE
fix(services): bound the association read loop so a stalled peer cannot park a slot

### DIFF
--- a/services/scp.go
+++ b/services/scp.go
@@ -132,6 +132,7 @@ type scp struct {
 	canceledMessageIDs   map[uint16]struct{}
 
 	bufSize         int
+	idleTimeout     time.Duration
 	cancelPoll      time.Duration
 	cancelGrace     time.Duration
 	implClassUID    string
@@ -152,6 +153,18 @@ func WithReadBufferSize(n int) SCPOption {
 		if n > 0 {
 			s.bufSize = n
 		}
+	}
+}
+
+// WithAssociationIdleTimeout sets how long the SCP waits for a peer to begin
+// the next command before closing the association. The default is
+// defaultAssociationIdleTimeout; a non-positive value disables the bound.
+//
+// This applies only while waiting for a new command, not while a dataset is
+// being transferred, so a slow but active transfer is never interrupted.
+func WithAssociationIdleTimeout(d time.Duration) SCPOption {
+	return func(s *scp) {
+		s.idleTimeout = d
 	}
 }
 
@@ -216,6 +229,7 @@ func NewSCP(port int, opts ...SCPOption) SCP {
 		Port:               port,
 		canceledMessageIDs: make(map[uint16]struct{}),
 		bufSize:            scpBufSize,
+		idleTimeout:        defaultAssociationIdleTimeout,
 		cancelPoll:         cancelPollWindow,
 		cancelGrace:        cancelGraceWindow,
 		logger:             slog.Default(),
@@ -234,6 +248,7 @@ func NewSCPWithTLS(port int, cfg *tls.Config, opts ...SCPOption) SCP {
 		tlsConfig:          normalizeServerTLSConfig(cfg),
 		canceledMessageIDs: make(map[uint16]struct{}),
 		bufSize:            scpBufSize,
+		idleTimeout:        defaultAssociationIdleTimeout,
 		cancelPoll:         cancelPollWindow,
 		cancelGrace:        cancelGraceWindow,
 		logger:             slog.Default(),

--- a/services/scp_association.go
+++ b/services/scp_association.go
@@ -174,8 +174,31 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			dco = queuedCommands[0]
 			queuedCommands = queuedCommands[1:]
 		} else {
+			// Bound the wait for the next command. This read is where a stalled
+			// peer parks: it previously had no deadline, so one connection that
+			// sent a few bytes and stopped held its goroutine — and a slot in the
+			// association semaphore — indefinitely.
+			//
+			// The deadline is cleared immediately after, so the dataset reads that
+			// follow a command are not bounded by it and a slow but active
+			// transfer is never interrupted. pollCommand manages its own, much
+			// shorter, cancel-poll deadline on a separate path and is unaffected.
+			if s.idleTimeout > 0 {
+				if dlErr := conn.SetReadDeadline(time.Now().Add(s.idleTimeout)); dlErr != nil {
+					pdu.Logger().Error("failed to set idle deadline", "error", dlErr)
+					return
+				}
+			}
 			dco, err = pdu.NextPDU()
+			if s.idleTimeout > 0 {
+				_ = conn.SetReadDeadline(time.Time{})
+			}
 			if err != nil {
+				if isReadTimeout(err) {
+					pdu.Logger().Warn("closing idle association",
+						"idle_timeout", s.idleTimeout)
+					return
+				}
 				if errors.Is(err, io.EOF) {
 					pdu.Logger().Debug("connection closed (EOF)")
 				} else if !errors.Is(err, network.ErrAssociationReleased) &&

--- a/services/scp_idle_test.go
+++ b/services/scp_idle_test.go
@@ -1,0 +1,70 @@
+package services
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestStalledPeerIsDisconnected is the slowloris regression.
+//
+// The association read loop called NextPDU with no read deadline, so a peer that
+// connected, wrote a few bytes of a PDU header and then went silent parked the
+// handler goroutine forever. Nothing in the SCP ever reclaimed it: SetTimeout is
+// applied only on the client dial path, never on accept.
+func TestStalledPeerIsDisconnected(t *testing.T) {
+	const port = 11473
+	// StartSCP registers its own t.Cleanup; calling the returned func too would
+	// Stop the SCP twice.
+	StartSCP(t, port, WithAssociationIdleTimeout(150*time.Millisecond))
+
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Three bytes of an A-ASSOCIATE-RQ header, then silence — never enough to
+	// complete a PDU, so the server stays blocked in its read.
+	if _, err := conn.Write([]byte{0x01, 0x00, 0x00}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// The server must close on us. Read with a deadline generously above the
+	// idle timeout: without the bound this read hits its own deadline instead.
+	if err := conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	start := time.Now()
+	var buf [1]byte
+	_, err = conn.Read(buf[:])
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("server sent data to a peer that never completed a PDU")
+	}
+	if ne, ok := err.(net.Error); ok && ne.Timeout() {
+		t.Fatalf("server held a stalled connection open for %v — the idle "+
+			"timeout did not fire (slowloris: one such peer per association slot "+
+			"locks out every legitimate client)", elapsed)
+	}
+	// Any other error means the far end closed: that is the fix working.
+	t.Logf("stalled peer disconnected after %v (%v)", elapsed, err)
+}
+
+// TestIdleTimeoutDoesNotBreakLiveAssociations guards the bound from severing
+// connections that are merely between commands rather than abandoned.
+func TestIdleTimeoutDoesNotBreakLiveAssociations(t *testing.T) {
+	s := NewSCP(0).(*scp)
+	if s.idleTimeout != defaultAssociationIdleTimeout {
+		t.Fatalf("default idle timeout is %v, want %v",
+			s.idleTimeout, defaultAssociationIdleTimeout)
+	}
+	// The bound must be opt-out, for deployments with long-lived idle peers.
+	s2 := NewSCP(0, WithAssociationIdleTimeout(0)).(*scp)
+	if s2.idleTimeout != 0 {
+		t.Fatalf("WithAssociationIdleTimeout(0) left %v, want the bound disabled",
+			s2.idleTimeout)
+	}
+}

--- a/services/scp_server.go
+++ b/services/scp_server.go
@@ -17,6 +17,19 @@ const scpBufSize = 256 * 1024
 // DIMSE commands, including in-flight C-CANCEL, during active operations.
 const cancelPollWindow = 5 * time.Millisecond
 
+// defaultAssociationIdleTimeout bounds how long the SCP waits for a peer to
+// begin the next command.
+//
+// The association read loop called NextPDU with no deadline at all, so a peer
+// that opened a connection, sent a few bytes and stalled held its goroutine —
+// and, with WithMaxAssociations configured, a slot in the semaphore — forever.
+// N such connections lock out every legitimate client. SetTimeout does not help:
+// it is only applied on the client dial path, never on the accept path.
+//
+// The bound applies only while waiting for a new command, never during a dataset
+// transfer, so a slow but active transfer is not interrupted.
+const defaultAssociationIdleTimeout = 60 * time.Second
+
 // cancelGraceWindow bounds how long SCP waits for a handler to exit after a
 // matching C-CANCEL is received before aborting the association.
 const cancelGraceWindow = 250 * time.Millisecond


### PR DESCRIPTION
## The problem

The association read loop called `NextPDU` with **no read deadline**. A peer that connected, wrote a few bytes of a PDU header and then went silent left the handler goroutine blocked in that read forever.

Nothing reclaimed it. `SetTimeout` looks like it would, but it is only applied on the client dial path — never on accept.

With `WithMaxAssociations` configured, each stalled connection also holds a slot in the association semaphore, so N such peers lock out every legitimate client. The attacker needs no valid protocol exchange to do this — **three bytes is enough** — so it is reachable pre-authentication.

## The fix

`WithAssociationIdleTimeout` (default 60s; non-positive disables the bound) caps how long the SCP waits for a peer to *begin* the next command.

The deadline is cleared the moment `NextPDU` returns, so:

- the dataset reads that follow a command are **not** covered by it — a slow but active transfer is never interrupted;
- `pollCommand`'s much shorter cancel-poll deadline is on a separate path and is untouched, so C-CANCEL polling still works.

I'd flagged this earlier as needing a design decision, on the assumption a deadline would have to go in `readIncomingPDU` and would then clash with the 5 ms cancel-poll window. That turned out to be wrong: the main loop and `pollCommand` are separate call sites, and only the main one was unprotected. **Making this call rather than asking — say if you'd rather have a different default than 60s.**

## Verification

`TestStalledPeerIsDisconnected` dials, writes 3 bytes, and asserts the server hangs up:

- **enforcement neutered** (`git stash` on `scp_association.go`): connection held for the full 3s test deadline — unbounded in reality → FAIL
- **fix in place**: peer disconnected at 151ms against a 150ms timeout, with EOF → PASS

Also run: full `go test ./...`, `go vet ./...`, `go test -race ./services/ ./network/`, 15s of `FuzzAssociationACReadDynamic`, and builds of all three Go consumers (io-scp, io-router, io-dicom-tools/go-bridge). All green.

## Known residual

This bounds the wait *between* commands, which is the pre-authentication vector. A peer that sends a valid command header and then dribbles its dataset is still only bounded in total bytes (by the ceiling from #50), not in time. Closing that needs a per-PDU progress deadline in `readIncomingPDU`, which does collide with the cancel-poll window — a larger change, deliberately not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)