### PR TITLE
fix(rle): stop colour-converting YBR_FULL so the photometric tag stays truthful

### DIFF
--- a/codecs/rle/rle.go
+++ b/codecs/rle/rle.go
@@ -3,7 +3,6 @@ package rle
 import (
 	"encoding/binary"
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -176,16 +175,6 @@ func readSegment(in []byte, out []byte, segmentOffset uint32, segmentSize uint32
 	return nil
 }
 
-func clampByte(v float32) byte {
-	if v <= 0 {
-		return 0
-	}
-	if v >= 255 {
-		return 255
-	}
-	return byte(math.Round(float64(v)))
-}
-
 func RLEdecode(in []byte, out []byte, length uint32, size uint32, photoInt string) error {
 	if len(in) < 64 || len(out) < int(size) || length == 0 || length > uint32(len(in)) {
 		return fmt.Errorf("ERROR, overflow decoding RLE")
@@ -223,21 +212,6 @@ func RLEdecode(in []byte, out []byte, length uint32, size uint32, photoInt strin
 		if err := readSegment(in, temp, segmentOffset[i], segmentLength, i, decodedPlaneSize); err != nil {
 			return err
 		}
-	}
-
-	offset := decodedPlaneSize
-
-	// YBR_FULL keeps its dedicated path because it also colour-converts to RGB.
-	if photoInt == "YBR_FULL" && segmentCount == 3 {
-		for i := uint32(0); i < decodedPlaneSize; i++ {
-			y := float32(temp[i])
-			cb := float32(temp[i+offset])
-			cr := float32(temp[i+2*offset])
-			out[3*i] = clampByte(y + 1.402*(cr-128.0))
-			out[3*i+1] = clampByte(y - 0.344136*(cb-128.0) - 0.714136*(cr-128.0))
-			out[3*i+2] = clampByte(y + 1.772*(cb-128.0))
-		}
-		return nil
 	}
 
 	// Everything else is a planar de-interleave. DICOM RLE (PS3.5 Annex G)

--- a/codecs/rle/ybr_test.go
+++ b/codecs/rle/ybr_test.go
@@ -1,0 +1,91 @@
+package rle
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestYBRFullRoundTripIsLossless is the regression for the decoder's silent
+// colour conversion.
+//
+// RLEdecode used to convert YBR_FULL to RGB in place, but nothing in the
+// library rewrites PhotometricInterpretation, so callers received RGB samples
+// still labelled YBR_FULL. Two things followed:
+//
+//   - a conformant consumer, trusting the tag, converted a second time and got
+//     wrong colours;
+//   - RLEencode does no conversion of its own, so encode-then-decode of a
+//     YBR_FULL image was not the identity — it silently corrupted the pixels.
+//
+// This test pins the second symptom, which needs no consumer to demonstrate.
+// RLE is lossless: what goes in must come out.
+func TestYBRFullRoundTripIsLossless(t *testing.T) {
+	const (
+		rows = 8
+		cols = 8
+	)
+	// Chroma values well away from 128 so any YBR<->RGB matrix visibly moves
+	// them; a neutral grey would survive the conversion and hide the bug.
+	src := make([]byte, rows*cols*3)
+	for i := 0; i < rows*cols; i++ {
+		src[3*i] = byte(30 + i%200)  // Y
+		src[3*i+1] = byte(200 - i%7) // Cb
+		src[3*i+2] = byte(20 + i%11) // Cr
+	}
+
+	enc, err := RLEencode(src, rows, cols, 8, 3)
+	if err != nil {
+		t.Fatalf("RLEencode: %v", err)
+	}
+
+	got := make([]byte, len(src))
+	if err := RLEdecode(enc, got, uint32(len(enc)), uint32(len(got)), "YBR_FULL"); err != nil {
+		t.Fatalf("RLEdecode: %v", err)
+	}
+
+	if !bytes.Equal(got, src) {
+		var idx int
+		for i := range src {
+			if src[i] != got[i] {
+				idx = i
+				break
+			}
+		}
+		t.Fatalf("YBR_FULL round-trip is not lossless: first difference at byte %d "+
+			"(sent %d, got %d) — the decoder is colour-converting samples the "+
+			"encoder never converted", idx, src[idx], got[idx])
+	}
+}
+
+// TestRGBAndYBRDecodeIdentically pins the contract that the decoder returns
+// samples exactly as stored, letting PhotometricInterpretation describe them.
+// The photometric name selects sample count, never a colour transform.
+func TestRGBAndYBRDecodeIdentically(t *testing.T) {
+	const rows, cols = 4, 4
+	src := make([]byte, rows*cols*3)
+	for i := range src {
+		src[i] = byte(i*13 + 7)
+	}
+	enc, err := RLEencode(src, rows, cols, 8, 3)
+	if err != nil {
+		t.Fatalf("RLEencode: %v", err)
+	}
+
+	asRGB := make([]byte, len(src))
+	if err := RLEdecode(enc, asRGB, uint32(len(enc)), uint32(len(asRGB)), "RGB"); err != nil {
+		t.Fatalf("decode as RGB: %v", err)
+	}
+	asYBR := make([]byte, len(src))
+	if err := RLEdecode(enc, asYBR, uint32(len(enc)), uint32(len(asYBR)), "YBR_FULL"); err != nil {
+		t.Fatalf("decode as YBR_FULL: %v", err)
+	}
+
+	if !bytes.Equal(asRGB, asYBR) {
+		t.Fatalf("the same 3-segment stream decoded differently under RGB and "+
+			"YBR_FULL; the codec must not apply a colour transform\nRGB: %v\nYBR: %v",
+			asRGB[:12], asYBR[:12])
+	}
+	if !bytes.Equal(asRGB, src) {
+		t.Fatalf("decode did not reproduce the encoded samples")
+	}
+}


### PR DESCRIPTION
Part 1 of 2. **Merge this before innovative-io/io-scp's companion PR** — io-scp builds against `../io-dicom` via a `replace` directive, so landing the renderer change first would double-convert RLE colour.

## The problem

`RLEdecode` converted `YBR_FULL` to RGB in place. Nothing in this library rewrites `PhotometricInterpretation`, so callers got RGB samples still labelled `YBR_FULL`.

It was the **only** codec doing this — JPEG, JPEG 2000 and JPEG-LS all return samples exactly as the tag describes.

Two consequences:

1. A conformant consumer, trusting the tag, converts a second time and renders wrong colours.
2. `RLEencode` applies no transform of its own, so **encode-then-decode of a `YBR_FULL` image was not the identity**. RLE is a lossless transfer syntax; it was silently corrupting pixels.

Symptom 2 needs no consumer to demonstrate, which is what the tests pin.

## The fix

`YBR_FULL` falls through to the general planar de-interleave (3 samples, 1 byte each) — the layout the segments already describe. `clampByte` went with the branch as its only caller.

The codec's contract is now uniform: samples come back as `PhotometricInterpretation` describes them, and the transform belongs to whoever honours the tag.

## Verification

Both tests fail against the previous behaviour (verified by `git stash` on `rle.go`):

- `TestYBRFullRoundTripIsLossless` — round-trip differs at byte 0 (sent 30, got 0)
- `TestRGBAndYBRDecodeIdentically` — the same 3-segment stream decoded differently under `RGB` and `YBR_FULL`

Full `go test ./...` and `go vet ./...` green.

## Noted while here, not fixed here

The JPEG 2000 decoder parses the `mct` flag from the COD marker (`gojp2k_codestream.go:328`) and never reads it again — there is no inverse ICT or RCT anywhere in the package. Colour J2K encoded with the multi-component transform (the usual case for `YBR_ICT`/`YBR_RCT`) therefore decodes to unconverted component planes. Our own encoder writes `mct: 0`, which is why round-trip tests never caught it. Separate PR to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)