### PR TITLE
fix(jpeg2000): apply the inverse multi-component transform

### DIFF
--- a/codecs/jpeg2000/gojp2k_decode.go
+++ b/codecs/jpeg2000/gojp2k_decode.go
@@ -206,8 +206,17 @@ func decodeTileComponent(cs *j2kCodestream, frame []byte, tc *tileComp) ([]int32
 		samples = idwt53(tc, band)
 	}
 
-	// DC level shift for unsigned components.
-	ci := cs.comps[tc.comp]
+	// The DC level shift is deliberately NOT applied here. T.800 Annex G orders
+	// the inverse multi-component transform before it, and the MCT needs all
+	// three components together, so goJ2Kdecode calls finishComponent after.
+	return samples, nil
+}
+
+// finishComponent applies the DC level shift and range clamp to one component's
+// samples, in place. Split out of decodeTileComponent so the inverse MCT can run
+// first, on the DC-centred values it is defined over.
+func finishComponent(cs *j2kCodestream, comp int, samples []int32) {
+	ci := cs.comps[comp]
 	if !ci.signed {
 		shift := int32(1) << uint(ci.precision-1)
 		for i := range samples {
@@ -232,7 +241,44 @@ func decodeTileComponent(cs *j2kCodestream, frame []byte, tc *tileComp) ([]int32
 			samples[i] = hi
 		}
 	}
-	return samples, nil
+}
+
+// inverseMCT undoes the multi-component transform across the first three
+// components, in place, per ITU-T T.800 Annex G.
+//
+// reversible selects the RCT (G.2), which pairs with the 5/3 wavelet, over the
+// ICT (G.1), which pairs with 9/7. Components beyond the first three (e.g.
+// alpha) are untransformed and left alone.
+//
+// The COD marker's MCT flag was parsed into codingStyle.mct but never read, so
+// no inverse transform ran at all: colour codestreams encoded with the MCT —
+// the usual case for YBR_ICT and YBR_RCT — decoded to raw component planes.
+func inverseMCT(planes [][]int32, reversible bool) {
+	n := len(planes[0])
+	if len(planes[1]) != n || len(planes[2]) != n {
+		return // mismatched geometry: not MCT-eligible, leave untouched
+	}
+	y0, y1, y2 := planes[0], planes[1], planes[2]
+	if reversible {
+		for i := 0; i < n; i++ {
+			// Arithmetic shift, not division: T.800 specifies floor, and Go's
+			// integer division truncates toward zero for negative sums.
+			g := y0[i] - ((y1[i] + y2[i]) >> 2)
+			r := y2[i] + g
+			b := y1[i] + g
+			y0[i], y1[i], y2[i] = r, g, b
+		}
+		return
+	}
+	for i := 0; i < n; i++ {
+		fy, fcb, fcr := float64(y0[i]), float64(y1[i]), float64(y2[i])
+		r := fy + 1.402*fcr
+		g := fy - 0.34413*fcb - 0.71414*fcr
+		b := fy + 1.772*fcb
+		y0[i] = int32(math.Round(r))
+		y1[i] = int32(math.Round(g))
+		y2[i] = int32(math.Round(b))
+	}
 }
 
 // goJ2Kdecode decodes a raw JPEG 2000 codestream into out using the codec's
@@ -293,6 +339,16 @@ func goJ2Kdecode(frame, out []byte) error {
 			return err
 		}
 		planes[c] = s
+	}
+
+	// Inverse multi-component transform, before the DC level shift (T.800
+	// Annex G). The reversible RCT pairs with the 5/3 wavelet, the irreversible
+	// ICT with 9/7; the tile-component's transform byte distinguishes them.
+	if cs.cod.mct != 0 && nc >= 3 {
+		inverseMCT(planes, tcs[0].style.transform == 1)
+	}
+	for c := 0; c < nc; c++ {
+		finishComponent(cs, c, planes[c])
 	}
 
 	// Pack component-interleaved, little-endian.

--- a/codecs/jpeg2000/mct_test.go
+++ b/codecs/jpeg2000/mct_test.go
@@ -1,0 +1,160 @@
+package jpeg2000
+
+import (
+	"bytes"
+	"testing"
+)
+
+// setCODMCT flips the multi-component-transform flag in the codestream's COD
+// segment. Layout per PS3.5 / ITU-T T.800 A.6.1: marker FF52, then a two-byte
+// segment length, then Scod, SGcod (progression, layers, MCT). parseCOD reads
+// the segment body from just past the length, so MCT is body[4].
+func setCODMCT(t *testing.T, cs []byte, v byte) []byte {
+	t.Helper()
+	out := append([]byte(nil), cs...)
+	for i := 0; i+1 < len(out); i++ {
+		if out[i] != 0xFF || out[i+1] != 0x52 {
+			continue
+		}
+		body := i + 4 // skip marker (2) + Lcod (2)
+		if body+4 >= len(out) {
+			t.Fatalf("COD segment at %d is truncated", i)
+		}
+		out[body+4] = v
+		return out
+	}
+	t.Fatalf("no COD marker (FF52) found in codestream")
+	return nil
+}
+
+// TestInverseMCTIsApplied pins that the decoder honours the multi-component
+// transform flag it parses.
+//
+// parseCOD reads Scod/SGcod into codingStyle.mct, but nothing on the decode
+// path ever reads that field back — there is no inverse ICT or RCT in the
+// package. Colour JPEG 2000 encoded with the MCT (the usual case for
+// YBR_ICT and YBR_RCT) therefore decodes to raw, unconverted component planes
+// and renders with badly wrong colours.
+//
+// The encoder in this package always writes mct=0, which is why round-trip
+// tests never exposed this. The test instead takes a known-good mct=0
+// codestream and flips only that one byte: a decoder that honours the flag must
+// produce different output, because it would now apply an inverse transform
+// that was never applied at encode time.
+func TestInverseMCTIsApplied(t *testing.T) {
+	// Pin the pure-Go backend: other tests in this package leave SetBackend(nil)
+	// installed, under which J2Kencode passes bytes through and emits no
+	// codestream at all.
+	if err := UseBackend("gojpeg2000"); err != nil {
+		t.Fatalf("UseBackend(gojpeg2000): %v", err)
+	}
+	t.Cleanup(func() { SetBackend(nil) })
+
+	const w, h = 16, 16
+	// Strongly non-grey samples: an inverse RCT/ICT on neutral data is close to
+	// a no-op and would hide the difference.
+	src := make([]byte, w*h*3)
+	for i := 0; i < w*h; i++ {
+		src[3*i] = byte(200 - i%97)
+		src[3*i+1] = byte(20 + i%53)
+		src[3*i+2] = byte(120 + i%31)
+	}
+
+	var enc []byte
+	var encSize int
+	if err := J2Kencode(src, w, h, 3, 8, &enc, &encSize, 0); err != nil {
+		t.Skipf("J2K encoder unavailable: %v", err)
+	}
+	enc = enc[:encSize]
+
+	plain := make([]byte, len(src))
+	if err := J2Kdecode(enc, uint32(len(enc)), plain); err != nil {
+		t.Fatalf("decode of mct=0 codestream: %v", err)
+	}
+
+	withMCT := setCODMCT(t, enc, 1)
+	got := make([]byte, len(src))
+	if err := J2Kdecode(withMCT, uint32(len(withMCT)), got); err != nil {
+		t.Fatalf("decode of mct=1 codestream: %v", err)
+	}
+
+	if bytes.Equal(got, plain) {
+		t.Fatalf("setting the COD multi-component-transform flag changed nothing: "+
+			"the decoder parses mct (gojp2k_codestream.go parseCOD) and never "+
+			"applies the inverse transform, so colour J2K encoded with the MCT — "+
+			"the usual case for YBR_ICT and YBR_RCT — decodes to unconverted "+
+			"component planes (first sample %d,%d,%d)", got[0], got[1], got[2])
+	}
+}
+
+// forwardRCT is the encoder-side reversible transform from T.800 G.2, written
+// here so the inverse can be checked for exactness rather than merely for
+// "output changed".
+func forwardRCT(r, g, b int32) (y0, y1, y2 int32) {
+	y0 = (r + 2*g + b) >> 2
+	y1 = b - g
+	y2 = r - g
+	return
+}
+
+// TestInverseRCTIsExact pins the reversible path as a true inverse. The RCT is
+// lossless by construction, so forward-then-inverse must reproduce every
+// sample exactly — including negatives, where a `/4` would truncate toward zero
+// and T.800's floor requires an arithmetic shift.
+func TestInverseRCTIsExact(t *testing.T) {
+	var rs, gs, bs []int32
+	for r := int32(-128); r < 128; r += 7 {
+		for g := int32(-128); g < 128; g += 11 {
+			for b := int32(-128); b < 128; b += 13 {
+				rs = append(rs, r)
+				gs = append(gs, g)
+				bs = append(bs, b)
+			}
+		}
+	}
+	y0 := make([]int32, len(rs))
+	y1 := make([]int32, len(rs))
+	y2 := make([]int32, len(rs))
+	for i := range rs {
+		y0[i], y1[i], y2[i] = forwardRCT(rs[i], gs[i], bs[i])
+	}
+
+	inverseMCT([][]int32{y0, y1, y2}, true)
+
+	for i := range rs {
+		if y0[i] != rs[i] || y1[i] != gs[i] || y2[i] != bs[i] {
+			t.Fatalf("RCT round-trip failed at sample %d: sent (%d,%d,%d), got (%d,%d,%d)",
+				i, rs[i], gs[i], bs[i], y0[i], y1[i], y2[i])
+		}
+	}
+	t.Logf("verified %d samples", len(rs))
+}
+
+// TestInverseICTKnownValues checks the irreversible path against the T.800 G.1
+// matrix. Chroma is DC-centred here (no +128 offset): the inverse MCT runs
+// before the DC level shift.
+func TestInverseICTKnownValues(t *testing.T) {
+	cases := []struct{ y, cb, cr, wr, wg, wb int32 }{
+		{0, 0, 0, 0, 0, 0},       // neutral stays neutral
+		{50, 0, 0, 50, 50, 50},   // no chroma -> grey
+		{0, 0, 100, 140, -71, 0}, // Cr drives red
+		{0, 100, 0, 0, -34, 177}, // Cb drives blue
+	}
+	for _, tc := range cases {
+		y0 := []int32{tc.y}
+		y1 := []int32{tc.cb}
+		y2 := []int32{tc.cr}
+		inverseMCT([][]int32{y0, y1, y2}, false)
+		if abs32(y0[0]-tc.wr) > 1 || abs32(y1[0]-tc.wg) > 1 || abs32(y2[0]-tc.wb) > 1 {
+			t.Errorf("ICT(%d,%d,%d) = (%d,%d,%d), want (%d,%d,%d)",
+				tc.y, tc.cb, tc.cr, y0[0], y1[0], y2[0], tc.wr, tc.wg, tc.wb)
+		}
+	}
+}
+
+func abs32(v int32) int32 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}


### PR DESCRIPTION
Independent of #52 and innovative-io/io-scp#7 — branched off `main`, no ordering constraint.

## The problem

`parseCOD` reads the COD marker's MCT flag into `codingStyle.mct` (`gojp2k_codestream.go:328`) and **nothing on the decode path ever reads it back**. There is no inverse ICT or RCT anywhere in the package.

Colour JPEG 2000 encoded with the multi-component transform — the usual case for `YBR_ICT` (lossy) and `YBR_RCT` (lossless) — therefore decoded to raw, unconverted component planes and rendered with badly wrong colours.

The encoder in this package always writes `mct: 0`, which is why round-trip tests never caught it.

## The fix

`inverseMCT` implements both transforms from T.800 Annex G:

- **RCT** (G.2), reversible, pairs with the 5/3 wavelet
- **ICT** (G.1), irreversible, pairs with 9/7

The tile-component's transform byte selects between them. Components past the first three (e.g. alpha) are untransformed and left alone.

The transform is defined over DC-centred samples, so it must run *before* the DC level shift. That shift and the range clamp moved out of `decodeTileComponent` into a new `finishComponent`, which `goJ2Kdecode` calls once all planes exist. **When `mct=0` nothing changes** — the same operations run in the same order, which is why the existing J2K tests pass untouched.

The RCT uses an arithmetic shift, not `/4`: T.800 specifies floor and Go truncates toward zero.

## Verification

- `TestInverseMCTIsApplied` — flips *only* the COD MCT byte in an otherwise identical codestream. Before this change the decoded output was bit-identical either way (that is the bug); now it differs. I confirmed the mechanism directly too: with the flag set, sample 0 decodes `[221 229 121]` where the untransformed plane reads `[200 20 120]`.
- `TestInverseRCTIsExact` — forward-then-inverse reproduces all 17,760 probed samples exactly, spanning negatives. Rewriting the shift as `/4` fails it at sample 20 (`sent (-128,-117,-128), got (-129,-118,-129)`).
- `TestInverseICTKnownValues` — matches the G.1 matrix on hand-computed values.

The new test pins the pure-Go backend explicitly: other tests in this package leave `SetBackend(nil)` installed, under which `J2Kencode` passes bytes through and emits no codestream. Without pinning it passed alone and failed in-package.

`go test ./...` and `go vet ./...` green; io-scp, io-router and io-dicom-tools/go-bridge all build.

**Not verified locally:** the `ffmpeg`/`st2110` tagged build — this machine has no libavcodec via pkg-config. CI's `tagged-codec-tests` job covers it.

## Scope

This corrects the decoder. `YBR_ICT`/`YBR_RCT` are deliberately excluded from the renderer-side conversion in innovative-io/io-scp#7 precisely because undoing the MCT is the codec's job — with this merged, that layering is correct end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)