### PR TITLE
fix(transcoder): encode each JPEG frame from its own byte range

### DIFF
--- a/media/multiframe_16bit_test.go
+++ b/media/multiframe_16bit_test.go
@@ -1,0 +1,143 @@
+package media_test
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/dictionary/tags"
+	"github.com/innovative-io/io-dicom/dictionary/transfersyntax"
+	"github.com/innovative-io/io-dicom/media"
+	"github.com/innovative-io/io-dicom/transcoder"
+)
+
+// newMultiFrame16Object builds an uncompressed 16-bit grayscale object whose
+// frames are individually distinguishable, so a frame decoded from the wrong
+// byte offset cannot accidentally match.
+func newMultiFrame16Object(frames, cols, rows int) (media.DICOMObject, []byte) {
+	obj := media.NewEmptyDCMObj()
+	obj.SetTransferSyntax(transfersyntax.ExplicitVRLittleEndian)
+	obj.SetExplicitVR(true)
+
+	obj.Write(tags.SOPClassUID, "1.2.840.10008.5.1.4.1.1.7")
+	obj.Write(tags.SOPInstanceUID, "1.2.826.0.1.3680043.10.90.6")
+	obj.Write(tags.PatientName, "ROUNDTRIP^MF16")
+	obj.Write(tags.PatientID, "MF16-01")
+	obj.Write(tags.PhotometricInterpretation, "MONOCHROME2")
+	obj.Write(tags.PlanarConfiguration, 0)
+	obj.Write(tags.NumberOfFrames, fmt.Sprintf("%d", frames))
+	obj.Write(tags.Rows, uint16(rows))
+	obj.Write(tags.Columns, uint16(cols))
+	obj.Write(tags.BitsAllocated, 16)
+	obj.Write(tags.BitsStored, 16)
+	obj.Write(tags.HighBit, 15)
+	obj.Write(tags.PixelRepresentation, 0)
+
+	perFrame := cols * rows
+	pixels := make([]byte, frames*perFrame*2)
+	for f := 0; f < frames; f++ {
+		for i := 0; i < perFrame; i++ {
+			// A per-frame base keeps every frame's samples in a disjoint range.
+			v := uint16((f+1)*0x1000 + i)
+			binary.LittleEndian.PutUint16(pixels[(f*perFrame+i)*2:], v)
+		}
+	}
+	obj.Add(&media.DICOMTag{
+		Group: 0x7FE0, Element: 0x0010,
+		Length: uint32(len(pixels)), VR: "OW", Data: pixels,
+	})
+	return obj, pixels
+}
+
+// TestMultiFrame16BitLosslessRoundTrip pins per-frame pixel fidelity for the
+// 16-bit encoders, which the existing multi-frame coverage never checked: it
+// asserts only that ChangeTransferSyntax returns nil, and builds 8-bit objects.
+//
+// The transcoder computes offset as a BYTE offset
+// (j * cols * rows * bitsAllocated / 8) but handed the 16-bit JPEG encoders
+// img[offset/2:] — a sample index. For frame 0 that is 0 either way, which is
+// why single-frame images, the common case, hid it. From frame 1 on, the
+// encoder reads from half the intended byte position and encodes the wrong
+// pixels.
+//
+// These syntaxes are mathematically lossless, so a correct round-trip must
+// reproduce every input byte.
+func TestMultiFrame16BitLosslessRoundTrip(t *testing.T) {
+	useGoBackends(t)
+
+	const cols, rows, frames = 8, 8, 3
+	frameBytes := cols * rows * 2
+
+	for _, ts := range []*transfersyntax.TransferSyntax{
+		transfersyntax.JPEGLosslessSV1,
+		transfersyntax.JPEGLossless,
+	} {
+		t.Run(ts.Name, func(t *testing.T) {
+			obj, want := newMultiFrame16Object(frames, cols, rows)
+			if err := transcoder.ChangeTransferSyntax(obj, ts); err != nil {
+				// Not a skip: the encoders are present. An over-long slice
+				// fails encodeLosslessJPEG's exact-size check
+				// (width*height*samples*bps != len(raw)).
+				t.Fatalf("%s encode of a %d-frame object failed: %v", ts.Name, frames, err)
+			}
+
+			ctx := context.Background()
+			for f := 0; f < frames; f++ {
+				got, err := obj.GetDecompressedFrame(ctx, f)
+				if err != nil {
+					t.Fatalf("frame %d: GetDecompressedFrame: %v", f, err)
+				}
+				exp := want[f*frameBytes : (f+1)*frameBytes]
+				if len(got) < frameBytes {
+					t.Fatalf("frame %d: got %d bytes, want %d", f, len(got), frameBytes)
+				}
+				got = got[:frameBytes]
+				for i := range exp {
+					if got[i] != exp[i] {
+						gotV := binary.LittleEndian.Uint16(got[i&^1:])
+						wantV := binary.LittleEndian.Uint16(exp[i&^1:])
+						t.Fatalf("frame %d differs at byte %d: sample %#04x, want %#04x "+
+							"— the frame was encoded from the wrong offset in the "+
+							"multi-frame pixel buffer", f, i, gotV, wantV)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestMultiFrame16BitDCTEncodes covers the lossy 16-bit branches, which shared
+// the same offset arithmetic. These are DCT syntaxes so the pixels do not
+// round-trip exactly; what matters is that every frame encodes at all and the
+// object ends up with one fragment per frame.
+func TestMultiFrame16BitDCTEncodes(t *testing.T) {
+	useGoBackends(t)
+
+	const cols, rows, frames = 8, 8, 3
+	for _, ts := range []*transfersyntax.TransferSyntax{
+		transfersyntax.JPEGExtended12Bit,
+		transfersyntax.JPEGBaseline8Bit,
+	} {
+		t.Run(ts.Name, func(t *testing.T) {
+			obj, _ := newMultiFrame16Object(frames, cols, rows)
+			if err := transcoder.ChangeTransferSyntax(obj, ts); err != nil {
+				t.Fatalf("%s encode of a %d-frame object failed: %v", ts.Name, frames, err)
+			}
+			if got := obj.GetTransferSyntax().UID; got != ts.UID {
+				t.Fatalf("transfer syntax not updated: got %s want %s", got, ts.UID)
+			}
+			ctx := context.Background()
+			for f := 0; f < frames; f++ {
+				got, err := obj.GetDecompressedFrame(ctx, f)
+				if err != nil {
+					t.Fatalf("frame %d: GetDecompressedFrame: %v", f, err)
+				}
+				if len(got) < cols*rows {
+					t.Fatalf("frame %d decoded to %d bytes, too short for %dx%d",
+						f, len(got), cols, rows)
+				}
+			}
+		})
+	}
+}

--- a/transcoder/transcoder.go
+++ b/transcoder/transcoder.go
@@ -472,22 +472,18 @@ func compress(ctx context.Context, obj media.DICOMObject, i *int, img []byte, RG
 	case transfersyntax.JPEGLossless.UID:
 		index = beginEncapsulatedPixelData(obj, index)
 		for j = 0; j < frames; j++ {
-			offset = j * uint32(cols) * uint32(rows) * uint32(bitsa) / 8
-			if RGB {
-				offset = 3 * offset
-			}
+			// frameBounds gives this frame's [start,end). The previous code
+			// built a byte offset and then handed the 16-bit encoder
+			// img[offset/2:] — a sample index, and open-ended besides.
+			// encodeLosslessJPEG checks width*height*samples*bps == len(raw)
+			// exactly, so every multi-frame 16-bit object was rejected outright.
+			samples, start, end := frameBounds(j, cols, rows, bitsa, RGB)
 			if bitsa == 8 {
-				if RGB {
-					if err := jpeg.EIJG8encode(img[offset:], cols, rows, 3, &JPEGData, &JPEGBytes, 4); err != nil {
-						return err
-					}
-				} else {
-					if err := jpeg.EIJG8encode(img[offset:], cols, rows, 1, &JPEGData, &JPEGBytes, 4); err != nil {
-						return err
-					}
+				if err := jpeg.EIJG8encode(img[start:end], cols, rows, samples, &JPEGData, &JPEGBytes, 4); err != nil {
+					return err
 				}
 			} else {
-				if err := jpeg.EIJG16encodeContext(ctx, img[offset/2:], cols, rows, 1, &JPEGData, &JPEGBytes, 0); err != nil {
+				if err := jpeg.EIJG16encodeContext(ctx, img[start:end], cols, rows, samples, &JPEGData, &JPEGBytes, 0); err != nil {
 					return err
 				}
 			}
@@ -499,21 +495,14 @@ func compress(ctx context.Context, obj media.DICOMObject, i *int, img []byte, RG
 	case transfersyntax.JPEGBaseline8Bit.UID:
 		index = beginEncapsulatedPixelData(obj, index)
 		for j = 0; j < frames; j++ {
-			offset = j * uint32(cols) * uint32(rows) * uint32(bitsa) / 8
-			if RGB {
-				offset = 3 * offset
-				if err := jpeg.EIJG8encode(img[offset:], cols, rows, 3, &JPEGData, &JPEGBytes, 0); err != nil {
+			samples, start, end := frameBounds(j, cols, rows, bitsa, RGB)
+			if bitsa == 8 {
+				if err := jpeg.EIJG8encode(img[start:end], cols, rows, samples, &JPEGData, &JPEGBytes, 0); err != nil {
 					return err
 				}
 			} else {
-				if bitsa == 8 {
-					if err := jpeg.EIJG8encode(img[offset:], cols, rows, 1, &JPEGData, &JPEGBytes, 0); err != nil {
-						return err
-					}
-				} else {
-					if err := jpeg.EIJG12encodeContext(ctx, img[offset:], cols, rows, 1, &JPEGData, &JPEGBytes, 0); err != nil {
-						return err
-					}
+				if err := jpeg.EIJG12encodeContext(ctx, img[start:end], cols, rows, samples, &JPEGData, &JPEGBytes, 0); err != nil {
+					return err
 				}
 			}
 			index = appendEncapsulatedFrame(obj, index, JPEGData)
@@ -524,8 +513,8 @@ func compress(ctx context.Context, obj media.DICOMObject, i *int, img []byte, RG
 	case transfersyntax.JPEGExtended12Bit.UID:
 		index = beginEncapsulatedPixelData(obj, index)
 		for j = 0; j < frames; j++ {
-			offset = j * uint32(cols) * uint32(rows) * uint32(bitsa) / 8
-			if err := jpeg.EIJG12encodeContext(ctx, img[offset/2:], cols, rows, 1, &JPEGData, &JPEGBytes, 0); err != nil {
+			samples, start, end := frameBounds(j, cols, rows, bitsa, RGB)
+			if err := jpeg.EIJG12encodeContext(ctx, img[start:end], cols, rows, samples, &JPEGData, &JPEGBytes, 0); err != nil {
 				return err
 			}
 			index = appendEncapsulatedFrame(obj, index, JPEGData)


### PR DESCRIPTION
## The problem

The JPEG branches built a byte offset (`j * cols * rows * bitsAllocated / 8`) and then sliced with it three different ways:

| Branch | Slice |
|---|---|
| JPEG Lossless / SV1, >8 bit | `img[offset/2:]` |
| JPEG Extended 12-bit | `img[offset/2:]` |
| JPEG Baseline, >8 bit | `img[offset:]` — the *same* `EIJG12encodeContext` call Extended divided by two |

`offset/2` is a sample index, not a byte index. All three also ran **open-ended** to the end of the entire multi-frame buffer.

`encodeLosslessJPEG` checks `width*height*samples*bps == len(raw)` exactly, so this did not silently corrupt pixels — it **failed outright**. Transcoding to JPEG Lossless, JPEG Lossless SV1, JPEG Extended 12-bit or JPEG Baseline was broken for every object with more than one frame:

```
gojpeg: invalid input for lossless JPEG encode
```

Single-frame objects were unaffected: `offset` is 0 either way, and the open-ended slice happens to be exactly one frame long. That is why this survived — and why the existing multi-frame coverage missed it, building only 8-bit objects and asserting nothing about pixel content.

Same shape as the JPIP bug fixed earlier: an open-ended slice meeting an exact-size check.

## The fix

All three branches now take `frameBounds`' `[start,end)` and its sample count, exactly as the JPEG 2000, JPEG XL, JPEG-LS and JPIP branches already do.

**One behaviour change beyond the offsets:** RGB input above 8 bits on the Baseline path previously went to `EIJG8encode`, which would misread 16-bit samples. It now goes to `EIJG12encodeContext` with `samples=3`, consistent with the non-RGB path. Flagging it because it is not merely an offset correction.

## Verification

`TestMultiFrame16BitLosslessRoundTrip` and `TestMultiFrame16BitDCTEncodes` build 3-frame 16-bit objects whose frames occupy disjoint value ranges, so a frame read from the wrong offset cannot coincidentally match.

- Against the previous code, **all four syntaxes fail** (verified with `git stash` on `transcoder.go`).
- With the fix, the two lossless syntaxes round-trip every frame byte-for-byte, and the DCT pair encodes and decodes all frames.

`go test ./...`, `go vet ./...`, `go test -race ./media/ ./transcoder/` green; io-scp, io-router and io-dicom-tools/go-bridge build.

## Deliberately not included

The MPEG and SMPTE 2110 branches use the same open-ended `img[offset:]` pattern, but their offset arithmetic is already correct — no `/2` — so they work today and the loose slice is latent rather than broken. They sit behind the `ffmpeg`/`st2110` build tags, and this machine has no libavcodec via pkg-config, so I can neither compile nor exercise them. I'd rather not fold an unverifiable edit into a PR of verified ones; worth a follow-up on a host with the codec libraries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)