### PR TITLE
fix(cmd): contain C-STORE storage paths inside the datastore

### DIFF
--- a/cmd/io-dicom/main.go
+++ b/cmd/io-dicom/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -22,6 +23,82 @@ import (
 	"github.com/innovative-io/io-dicom/network/dicomstatus"
 	"github.com/innovative-io/io-dicom/services"
 )
+
+// safeComponent reduces one wire-supplied attribute to a single, inert path
+// element. Anything outside a conservative allow-list becomes '_', so a
+// separator or a traversal sequence cannot survive.
+func safeComponent(s string) string {
+	s = strings.TrimSpace(s)
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9',
+			r == '.', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	out := b.String()
+	// "", ".", ".." and friends are all path-significant rather than names.
+	if strings.Trim(out, ".") == "" {
+		return ""
+	}
+	if len(out) > 64 {
+		out = out[:64]
+	}
+	return out
+}
+
+// storagePath builds the on-disk path for a received instance and guarantees it
+// stays inside root.
+//
+// PatientID, StudyInstanceUID, SeriesInstanceUID and SOPInstanceUID all arrive
+// in the C-STORE payload from the remote peer. They were passed straight to
+// filepath.Join, which cleans a path but does not contain it: Join("/data",
+// "../../etc") is "/etc". A peer needed only to send PatientID "../../.." to
+// write a .dcm file anywhere this process could write, with no authentication.
+// PatientID is an LO, not a UID, so it carries arbitrary text by design.
+//
+// Each component is sanitised, and the assembled path is then re-checked
+// against root so that any future change to the sanitiser still cannot escape.
+func storagePath(root, patientID, studyUID, seriesUID, sopUID string) (string, error) {
+	parts := map[string]string{
+		"PatientID":         patientID,
+		"StudyInstanceUID":  studyUID,
+		"SeriesInstanceUID": seriesUID,
+		"SOPInstanceUID":    sopUID,
+	}
+	clean := make(map[string]string, len(parts))
+	for name, raw := range parts {
+		c := safeComponent(raw)
+		if c == "" {
+			return "", fmt.Errorf("unusable %s in received instance", name)
+		}
+		clean[name] = c
+	}
+
+	path := filepath.Join(root,
+		clean["PatientID"], clean["StudyInstanceUID"], clean["SeriesInstanceUID"],
+		clean["SOPInstanceUID"]+".dcm")
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(absRoot, absPath)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("refusing to write outside the datastore")
+	}
+	return path, nil
+}
 
 var version string
 
@@ -126,14 +203,23 @@ func main() {
 
 		scp.OnCStoreRequest(func(ctx context.Context, request network.AssociationRequest, data media.DICOMObject) uint16 {
 			slog.Info("C-Store received", "sop_instance_uid", data.GetString(tags.SOPInstanceUID))
-			directory := filepath.Join(*datastore, data.GetString(tags.PatientID), data.GetString(tags.StudyInstanceUID), data.GetString(tags.SeriesInstanceUID))
-			os.MkdirAll(directory, 0755)
-
-			path := filepath.Join(directory, data.GetString(tags.SOPInstanceUID)+".dcm")
-
-			err := data.WriteToFile(path)
+			path, err := storagePath(*datastore,
+				data.GetString(tags.PatientID),
+				data.GetString(tags.StudyInstanceUID),
+				data.GetString(tags.SeriesInstanceUID),
+				data.GetString(tags.SOPInstanceUID))
 			if err != nil {
+				slog.Error("refusing to store instance", "error", err)
+				return dicomstatus.FailureProcessingFailure
+			}
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				slog.Error("failed to create storage directory", "path", filepath.Dir(path), "error", err)
+				return dicomstatus.FailureProcessingFailure
+			}
+
+			if err := data.WriteToFile(path); err != nil {
 				slog.Error("failed to save instance", "path", path, "error", err)
+				return dicomstatus.FailureProcessingFailure
 			}
 			return dicomstatus.Success
 		})

--- a/cmd/io-dicom/storage_path_test.go
+++ b/cmd/io-dicom/storage_path_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestStoragePathContainsTraversal is the path-traversal regression.
+//
+// PatientID, StudyInstanceUID, SeriesInstanceUID and SOPInstanceUID all arrive
+// in the C-STORE payload from the remote peer, and were passed straight to
+// filepath.Join. Join cleans a path but does not contain it, so a peer sending
+// PatientID "../../.." wrote a .dcm file outside the datastore — with no
+// authentication, against a binary the Makefile installs.
+func TestStoragePathContainsTraversal(t *testing.T) {
+	root := t.TempDir()
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hostile := []struct {
+		name                        string
+		patient, study, series, sop string
+	}{
+		{"traversal in PatientID", "../../../../etc", "1.2.3", "1.2.4", "1.2.5"},
+		{"traversal in StudyUID", "PID", "../../..", "1.2.4", "1.2.5"},
+		{"traversal in SeriesUID", "PID", "1.2.3", "../..", "1.2.5"},
+		{"traversal in SOPUID", "PID", "1.2.3", "1.2.4", "../../../evil"},
+		{"absolute PatientID", "/etc/cron.d", "1.2.3", "1.2.4", "1.2.5"},
+		{"separator in PatientID", "a/b/../../../c", "1.2.3", "1.2.4", "1.2.5"},
+		{"dot-dot only", "..", "1.2.3", "1.2.4", "1.2.5"},
+		{"backslash separator", `..\..\windows`, "1.2.3", "1.2.4", "1.2.5"},
+		{"newline injection", "pid\n../../x", "1.2.3", "1.2.4", "1.2.5"},
+		{"nul byte", "pid\x00/../..", "1.2.3", "1.2.4", "1.2.5"},
+	}
+
+	for _, tc := range hostile {
+		t.Run(tc.name, func(t *testing.T) {
+			path, err := storagePath(root, tc.patient, tc.study, tc.series, tc.sop)
+			if err != nil {
+				return // rejected outright, which is fine
+			}
+			abs, err := filepath.Abs(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rel, err := filepath.Rel(absRoot, abs)
+			if err != nil {
+				t.Fatalf("Rel(%q, %q): %v", absRoot, abs, err)
+			}
+			if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				t.Fatalf("a peer escaped the datastore: %q resolved to %q (%q outside %q)",
+					tc.patient, path, rel, absRoot)
+			}
+		})
+	}
+}
+
+// TestStoragePathRejectsEmptyComponents pins that a missing Type-1 attribute
+// cannot collapse the hierarchy — without it, an absent SeriesInstanceUID would
+// silently write the instance one directory up.
+func TestStoragePathRejectsEmptyComponents(t *testing.T) {
+	root := t.TempDir()
+	cases := []struct{ patient, study, series, sop string }{
+		{"", "1.2.3", "1.2.4", "1.2.5"},
+		{"PID", "", "1.2.4", "1.2.5"},
+		{"PID", "1.2.3", "", "1.2.5"},
+		{"PID", "1.2.3", "1.2.4", ""},
+		{"   ", "1.2.3", "1.2.4", "1.2.5"},
+		{".", "1.2.3", "1.2.4", "1.2.5"},
+	}
+	for _, tc := range cases {
+		if p, err := storagePath(root, tc.patient, tc.study, tc.series, tc.sop); err == nil {
+			t.Errorf("storagePath(%q,%q,%q,%q) = %q, want an error",
+				tc.patient, tc.study, tc.series, tc.sop, p)
+		}
+	}
+}
+
+// TestStoragePathKeepsOrdinaryValues guards the sanitiser from mangling the
+// normal case: real UIDs are dotted digits and must survive untouched.
+func TestStoragePathKeepsOrdinaryValues(t *testing.T) {
+	root := t.TempDir()
+	path, err := storagePath(root, "PAT-001", "1.2.840.113619.2.55.3", "1.2.840.113619.2.55.4", "1.2.840.113619.2.55.5")
+	if err != nil {
+		t.Fatalf("storagePath on ordinary values: %v", err)
+	}
+	want := filepath.Join(root, "PAT-001", "1.2.840.113619.2.55.3",
+		"1.2.840.113619.2.55.4", "1.2.840.113619.2.55.5.dcm")
+	if path != want {
+		t.Fatalf("path = %q, want %q", path, want)
+	}
+}
+
+// TestSafeComponentReplacesSeparators pins the element-level guarantee the
+// containment check is layered on top of.
+func TestSafeComponentReplacesSeparators(t *testing.T) {
+	for _, in := range []string{"a/b", `a\b`, "a:b", "a b", "a\tb", "a\x00b"} {
+		got := safeComponent(in)
+		if strings.ContainsAny(got, `/\`) {
+			t.Errorf("safeComponent(%q) = %q, still contains a separator", in, got)
+		}
+	}
+	if got := safeComponent(strings.Repeat("x", 200)); len(got) > 64 {
+		t.Errorf("safeComponent did not bound length: got %d", len(got))
+	}
+}


### PR DESCRIPTION
## The problem

The C-STORE handler built its on-disk path like this:

```go
directory := filepath.Join(*datastore, data.GetString(tags.PatientID), ...StudyInstanceUID, ...SeriesInstanceUID)
os.MkdirAll(directory, 0755)
path := filepath.Join(directory, data.GetString(tags.SOPInstanceUID)+".dcm")
```

All four attributes arrive in the C-STORE payload **from the remote peer**. `filepath.Join` cleans a path but does not contain it — `Join("/data", "../../etc")` is `/etc`.

A peer needed only to send `PatientID: "../../.."` to write a `.dcm` file anywhere this process could write, **with no authentication**. `PatientID` is an LO, not a UID, so it carries arbitrary text by design — no malformed UID is required.

This is not sample code: the Makefile installs it (`go install ./cmd/io-dicom/`, lines 59 and 65).

Same class as the WADO path traversal fixed earlier, on a surface that had not been audited.

## The fix

`storagePath`:

1. Reduces each component to a conservative allow-list (`A-Za-z0-9._-`), so separators and traversal sequences cannot survive.
2. Rejects components that reduce to nothing path-significant — `""`, `"."`, `".."` — which otherwise collapse the hierarchy and write an instance a directory up.
3. Re-checks the assembled path against the datastore root with `filepath.Rel`, so a future change to the sanitiser still cannot escape.

Unusable components now fail the store with `FailureProcessingFailure` instead of writing somewhere unexpected.

**Two smaller fixes in the same handler**, both noticed while editing it:

- the `os.MkdirAll` error was discarded entirely;
- a failed `WriteToFile` was logged but the handler still returned `dicomstatus.Success`, so a sender was told its instance was stored when it was not.

## Verification

I reproduced the escape against the original construction verbatim:

```
ORIGINAL ESCAPED: ".../T/TestOriginalEscapes.../001" -> "/var/folders/h_/etc/1.2.3/1.2.4/1.2.5.dcm"
                                              (rel "../../../../etc/1.2.3/1.2.4/1.2.5.dcm")
```

`TestStoragePathContainsTraversal` probes ten hostile inputs — traversal in each of the four attributes, absolute paths, embedded separators, `..`-only, backslash and NUL forms — and asserts every result stays under the root. Plus tests that empty/`.`-only components are rejected and that ordinary dotted UIDs pass through byte-for-byte unmangled.

`go test ./...` and `go vet ./...` green; io-scp and io-router build.

## Audit status

This is the first finding from `cmd/` (1,962 LOC), which was previously unaudited. Two other things I looked at and am *not* changing: `cmd/io-dicom`'s `InsecureSkipVerify` is behind an explicit opt-in `-tls-insecure` flag, and the `http.Get` calls in `update-dictionaries`/`utilities` are developer tooling run by hand against fixed URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)