### PR TITLE
fix(network): bound each read so a peer cannot dribble a dataset indefinitely

### DIFF
--- a/dimse/dimse_test.go
+++ b/dimse/dimse_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/innovative-io/io-dicom/dictionary/tags"
 	"github.com/innovative-io/io-dicom/dictionary/transfersyntax"
@@ -70,6 +71,7 @@ func (m *mockPDU) SetCalledAE(_ string)                                         
 func (m *mockPDU) SetCallingAE(_ string)                                           {}
 func (m *mockPDU) SetConn(_ *bufio.ReadWriter)                                     {}
 func (m *mockPDU) SetNetConn(_ net.Conn)                                           {}
+func (m *mockPDU) SetReadDeadline(_ time.Time) error                               { return nil }
 func (m *mockPDU) AddPresContexts(_ network.PresentationContext)                   {}
 func (m *mockPDU) SetOnAssociationRequest(_ func(network.AssociationRequest) bool) {}
 func (m *mockPDU) SetOnRawPDU(_ func(network.RawPDUEvent))                         {}

--- a/network/pdu_service.go
+++ b/network/pdu_service.go
@@ -68,6 +68,11 @@ type PDUService interface {
 	SetCallingAE(callingAE string)
 	SetConn(rw *bufio.ReadWriter)
 	SetNetConn(conn net.Conn)
+	// SetReadDeadline bounds the next read with an absolute deadline. Pass the
+	// zero Time to clear it. Callers must use this rather than setting the
+	// deadline on the connection directly, so the per-read progress timeout can
+	// take it into account instead of overwriting it.
+	SetReadDeadline(t time.Time) error
 	NextPDU() (media.DICOMObject, error)
 	AddPresContexts(presentationContext PresentationContext)
 	GetPresentationContextID() byte
@@ -111,6 +116,19 @@ func WithMaxMessageSize(n int) PDUServiceOption {
 	}
 }
 
+// WithReadProgressTimeout bounds how long a single read may take without
+// completing. A non-positive value disables the bound; omitted, the default is
+// defaultReadProgressTimeout.
+//
+// This is a progress bound, not a transfer bound: it is re-armed before every
+// read, so an arbitrarily large transfer may take arbitrarily long as long as
+// it keeps moving. Only a peer that stops feeding bytes mid-PDU trips it.
+func WithReadProgressTimeout(d time.Duration) PDUServiceOption {
+	return func(p *pduService) {
+		p.progressTimeout = d
+	}
+}
+
 // WithLogger sets the structured logger used for PDU-level events on this
 // connection. By default the library logs through slog.Default(). Pass a logger
 // derived with per-association attributes to correlate concurrent associations.
@@ -124,6 +142,8 @@ type pduService struct {
 	AcceptedPresentationContexts []PresentationContextAccept
 	conn                         net.Conn
 	readWriter                   *bufio.ReadWriter
+	progressTimeout              time.Duration
+	externalDeadline             time.Time
 	buf                          *media.DICOMBuffer
 	pdutype                      int
 	pdulength                    uint32
@@ -163,6 +183,7 @@ type pduService struct {
 func NewPDUService(opts ...PDUServiceOption) PDUService {
 	p := &pduService{
 		maxMessageBytes: defaultMaxMessageBytes,
+		progressTimeout: defaultReadProgressTimeout,
 		buf:             media.NewDICOMBuffer(),
 		AssocRQ:         newAssociationRequest(),
 		AssocAC:         newAssociationAccept(),
@@ -235,6 +256,20 @@ const maxIncomingPDULength uint32 = 16 << 20
 // objects.
 const defaultMaxMessageBytes = 1 << 30
 
+// defaultReadProgressTimeout bounds a single read on an established
+// association.
+//
+// The idle timeout in the services layer covers a peer that goes quiet between
+// commands, but once a command had been accepted the dataset reads that
+// followed were unbounded: a peer could send a valid C-STORE header and then
+// dribble its dataset forever, held only by the total-message ceiling, which
+// bounds bytes rather than time.
+//
+// One PDU is capped at maxIncomingPDULength (16 MiB), so this only requires a
+// peer to sustain progress within a single read — it never limits how long a
+// whole study takes to arrive.
+const defaultReadProgressTimeout = 60 * time.Second
+
 const releaseHandshakeTimeout = 5 * time.Second
 
 // resolveImplClass returns the implementation class UID and version to use
@@ -249,6 +284,37 @@ func (pdu *pduService) resolveImplClass() (uid, version string) {
 
 func (pdu *pduService) SetConn(rw *bufio.ReadWriter) {
 	pdu.readWriter = rw
+}
+
+// SetReadDeadline records an absolute deadline for the next read and applies it
+// immediately. applyReadDeadline keeps it in force when it is sooner than the
+// per-read progress timeout, so a short poll (e.g. the SCP's C-CANCEL window)
+// is never lengthened by the progress bound.
+func (pdu *pduService) SetReadDeadline(t time.Time) error {
+	pdu.externalDeadline = t
+	if pdu.conn == nil {
+		return nil
+	}
+	return pdu.conn.SetReadDeadline(t)
+}
+
+// applyReadDeadline arms the connection for one read, using whichever of the
+// caller's deadline and the progress timeout expires first.
+func (pdu *pduService) applyReadDeadline() error {
+	if pdu.conn == nil {
+		return nil
+	}
+	var eff time.Time
+	if pdu.progressTimeout > 0 {
+		eff = time.Now().Add(pdu.progressTimeout)
+	}
+	if !pdu.externalDeadline.IsZero() && (eff.IsZero() || pdu.externalDeadline.Before(eff)) {
+		eff = pdu.externalDeadline
+	}
+	if eff.IsZero() {
+		return nil
+	}
+	return pdu.conn.SetReadDeadline(eff)
 }
 
 func (pdu *pduService) SetNetConn(conn net.Conn) {
@@ -728,6 +794,9 @@ func (pdu *pduService) emitRawPDU(direction RawPDUDirection, pduType byte, data 
 
 func (pdu *pduService) readIncomingPDU() (byte, []byte, error) {
 	header := &pdu.hdrScratch
+	if err := pdu.applyReadDeadline(); err != nil {
+		return 0, nil, err
+	}
 	if _, err := io.ReadFull(pdu.readWriter, header[:]); err != nil {
 		return 0, nil, err
 	}
@@ -749,6 +818,11 @@ func (pdu *pduService) readIncomingPDU() (byte, []byte, error) {
 	data := make([]byte, 10+remaining)
 	copy(data, header[:])
 	if remaining > 0 {
+		// Re-arm: the body is a separate read, and a peer that delivered a
+		// header must still make progress on the payload.
+		if err := pdu.applyReadDeadline(); err != nil {
+			return 0, nil, err
+		}
 		if _, err := io.ReadFull(pdu.readWriter, data[10:]); err != nil {
 			return 0, nil, err
 		}

--- a/network/read_progress_test.go
+++ b/network/read_progress_test.go
@@ -1,0 +1,98 @@
+package network
+
+import (
+	"bufio"
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestStalledMidPDUReadIsBounded is the mid-transfer dribble regression.
+//
+// The services-layer idle timeout bounds a peer that goes quiet *between*
+// commands, but once a command was accepted the dataset reads that followed had
+// no deadline at all. A peer could announce a PDU and then simply stop feeding
+// bytes, held only by the total-message ceiling — which bounds bytes, not time.
+//
+// The deadline is per read, so this must fire while the payload is incomplete.
+func TestStalledMidPDUReadIsBounded(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	pdu := NewPDUService(WithReadProgressTimeout(150 * time.Millisecond)).(*pduService)
+	pdu.SetNetConn(server)
+	pdu.SetConn(bufio.NewReadWriter(bufio.NewReader(server), bufio.NewWriter(server)))
+	pdu.negotiated = true
+
+	// Announce a 4 KiB P-DATA PDU, send only a sliver of it, then stall.
+	go func() {
+		var hdr [10]byte
+		hdr[0] = 0x04
+		binary.BigEndian.PutUint32(hdr[2:6], 4096)
+		_, _ = client.Write(hdr[:])
+		_, _ = client.Write(make([]byte, 16))
+		select {} // never send the rest
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := pdu.readIncomingPDU()
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a peer that stopped mid-PDU was allowed to complete a read")
+		}
+		t.Logf("stalled mid-PDU read released with: %v", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("a peer that announced a PDU and stopped sending held the read " +
+			"open indefinitely — the per-read progress deadline did not fire")
+	}
+}
+
+// TestProgressDeadlineDoesNotOverrideShorterPoll pins the interaction that made
+// this awkward to bound in the first place: the SCP polls for an interleaved
+// C-CANCEL with a very short deadline, and a per-read progress timeout applied
+// naively would stretch that poll to its own much longer value.
+func TestProgressDeadlineDoesNotOverrideShorterPoll(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	pdu := NewPDUService(WithReadProgressTimeout(30 * time.Second)).(*pduService)
+	pdu.SetNetConn(server)
+	pdu.SetConn(bufio.NewReadWriter(bufio.NewReader(server), bufio.NewWriter(server)))
+	pdu.negotiated = true
+
+	// The caller's deadline is far sooner than the progress timeout.
+	if err := pdu.SetReadDeadline(time.Now().Add(20 * time.Millisecond)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+
+	start := time.Now()
+	_, _, err := pdu.readIncomingPDU() // peer sends nothing at all
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected the short poll deadline to expire")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("the caller's 20ms deadline was overridden by the 30s progress "+
+			"timeout: the read blocked for %v — C-CANCEL polling would stall", elapsed)
+	}
+}
+
+// TestProgressTimeoutCanBeDisabled keeps the bound opt-out for deployments that
+// manage their own deadlines.
+func TestProgressTimeoutCanBeDisabled(t *testing.T) {
+	if got := NewPDUService().(*pduService).progressTimeout; got != defaultReadProgressTimeout {
+		t.Fatalf("default progress timeout is %v, want %v", got, defaultReadProgressTimeout)
+	}
+	if got := NewPDUService(WithReadProgressTimeout(0)).(*pduService).progressTimeout; got != 0 {
+		t.Fatalf("WithReadProgressTimeout(0) left %v, want the bound disabled", got)
+	}
+}

--- a/services/scp_association.go
+++ b/services/scp_association.go
@@ -87,11 +87,11 @@ func (s *scp) pollCommand(conn net.Conn, pdu network.PDUService) (media.DICOMObj
 		return nil, nil
 	}
 
-	if err := conn.SetReadDeadline(time.Now().Add(s.cancelPoll)); err != nil {
+	if err := pdu.SetReadDeadline(time.Now().Add(s.cancelPoll)); err != nil {
 		return nil, err
 	}
 	dco, err := pdu.NextPDU()
-	_ = conn.SetReadDeadline(time.Time{})
+	_ = pdu.SetReadDeadline(time.Time{})
 
 	if err != nil {
 		if isReadTimeout(err) {
@@ -184,14 +184,14 @@ func (s *scp) handleConnection(ctx context.Context, conn net.Conn) {
 			// transfer is never interrupted. pollCommand manages its own, much
 			// shorter, cancel-poll deadline on a separate path and is unaffected.
 			if s.idleTimeout > 0 {
-				if dlErr := conn.SetReadDeadline(time.Now().Add(s.idleTimeout)); dlErr != nil {
+				if dlErr := pdu.SetReadDeadline(time.Now().Add(s.idleTimeout)); dlErr != nil {
 					pdu.Logger().Error("failed to set idle deadline", "error", dlErr)
 					return
 				}
 			}
 			dco, err = pdu.NextPDU()
 			if s.idleTimeout > 0 {
-				_ = conn.SetReadDeadline(time.Time{})
+				_ = pdu.SetReadDeadline(time.Time{})
 			}
 			if err != nil {
 				if isReadTimeout(err) {

--- a/services/scp_test.go
+++ b/services/scp_test.go
@@ -951,6 +951,7 @@ func (m *cgetStoreSubopMockPDU) SetCalledAE(_ string)                           
 func (m *cgetStoreSubopMockPDU) SetCallingAE(_ string)                                           {}
 func (m *cgetStoreSubopMockPDU) SetConn(_ *bufio.ReadWriter)                                     {}
 func (m *cgetStoreSubopMockPDU) SetNetConn(_ net.Conn)                                           {}
+func (m *cgetStoreSubopMockPDU) SetReadDeadline(_ time.Time) error                               { return nil }
 func (m *cgetStoreSubopMockPDU) AddPresContexts(_ network.PresentationContext)                   {}
 func (m *cgetStoreSubopMockPDU) SetOnAssociationRequest(_ func(network.AssociationRequest) bool) {}
 func (m *cgetStoreSubopMockPDU) SetOnRawPDU(_ func(network.RawPDUEvent))                         {}

--- a/services/scu_test.go
+++ b/services/scu_test.go
@@ -427,6 +427,7 @@ func (m *storeMockPDU) SetCalledAE(_ string)                          {}
 func (m *storeMockPDU) SetCallingAE(_ string)                         {}
 func (m *storeMockPDU) SetConn(_ *bufio.ReadWriter)                   {}
 func (m *storeMockPDU) SetNetConn(_ net.Conn)                         {}
+func (m *storeMockPDU) SetReadDeadline(_ time.Time) error             { return nil }
 func (m *storeMockPDU) NextPDU() (media.DICOMObject, error)           { return nil, nil }
 func (m *storeMockPDU) AddPresContexts(_ network.PresentationContext) {}
 func (m *storeMockPDU) GetAcceptedPresentationContexts() []network.PresentationContextAccept {


### PR DESCRIPTION
Closes the residual documented in #51.

## The problem

#51's idle timeout bounds a peer that goes quiet **between** commands — the pre-authentication case. But once a command had been accepted, the dataset reads that followed had **no deadline at all**.

A peer could send a valid C-STORE command header and then feed its dataset a byte at a time, forever. The only thing holding it back was the total-message ceiling from #50, which bounds *bytes*, not *time*.

## Why this wasn't done in #51

I flagged it there as needing a per-PDU progress deadline in `readIncomingPDU` that "does collide with the cancel-poll window". That was the real obstacle: the SCP polls for an interleaved C-CANCEL with a ~5 ms deadline set directly on the connection, and a progress timeout applied naively would overwrite it and stretch that poll to its own much longer value — silently breaking cancellation.

The fix is to stop having two owners of the connection deadline:

- `PDUService` gains `SetReadDeadline`.
- The services layer routes its cancel-poll and idle deadlines through that instead of calling `conn.SetReadDeadline` directly (no direct calls remain).
- `applyReadDeadline` arms each read with **whichever of the caller's deadline and the progress timeout expires first**.

## Progress bound, not transfer bound

`WithReadProgressTimeout` (default 60s; non-positive disables) is re-armed before *every* read, including separately for a PDU's header and its body. An arbitrarily large study may take arbitrarily long to arrive as long as it keeps moving — this never caps total transfer time. Since one PDU is capped at `maxIncomingPDULength` (16 MiB), the bound only asks a peer to sustain progress within a single read.

That distinction is why this is safe for slow clinical links, where a per-message deadline would not have been.

## Verification

Neutered in both directions, since this fix has two halves that can each fail independently:

| Neutered | Result |
|---|---|
| `applyReadDeadline` stubbed to `return nil` | peer announces a 4 KiB PDU, sends 16 bytes, stalls → read held past the 3s test bound → FAIL |
| caller's deadline ignored in `applyReadDeadline` | a 20 ms poll blocks for the full 30 s progress timeout → FAIL |

Both pass with the fix. My first attempt at the former was invalid — I changed the constructor default while the test sets the timeout explicitly via the option, so it proved nothing; the result above is from neutering the function itself.

Also run: full `go test ./...`, `go vet ./...`, `go test -race ./network/ ./services/`, 20s of `FuzzAssociationACReadDynamic`, and #51's `TestStalledPeerIsDisconnected` (still fires at ~152 ms, so the idle timeout is intact). io-scp, io-router and io-dicom-tools/go-bridge all build.

## Interface change

`PDUService` gains one method, so the three test mocks (`services/scp_test.go`, `services/scu_test.go`, `dimse/dimse_test.go`) each pick up a no-op `SetReadDeadline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)