### PR TITLE
fix(transcoder): encode each MPEG/SMPTE frame from its own byte range

### DIFF
--- a/media/multiframe_mpeg_test.go
+++ b/media/multiframe_mpeg_test.go
@@ -1,0 +1,73 @@
+package media_test
+
+import (
+	"testing"
+
+	"github.com/innovative-io/io-dicom/dictionary/transfersyntax"
+	"github.com/innovative-io/io-dicom/media"
+	"github.com/innovative-io/io-dicom/transcoder"
+)
+
+// encapsulatedFragmentSizes returns the byte length of every pixel-data
+// fragment (0xFFFE,0xE000 items) after the Basic Offset Table, in order.
+func encapsulatedFragmentSizes(obj media.DICOMObject) []int {
+	var sizes []int
+	seenBOT := false
+	for i := 0; i < obj.TagCount(); i++ {
+		t := obj.GetTagAt(i)
+		if t.Group != 0xFFFE || t.Element != 0xE000 {
+			continue
+		}
+		if !seenBOT {
+			seenBOT = true // first item is the (empty) Basic Offset Table
+			continue
+		}
+		sizes = append(sizes, len(t.Data))
+	}
+	return sizes
+}
+
+// TestMultiFrameMPEGFragmentSizes pins per-frame framing for the MPEG/HEVC and
+// SMPTE 2110 transcoder branches.
+//
+// Those branches sliced img[offset:] open-ended to the end of the whole
+// multi-frame buffer, so every frame but the last was handed too many bytes.
+// With the real ffmpeg/st2110 backend that trips an exact-size check and fails
+// the encode outright (as the analogous JPEG bug did); with the pure-Go
+// passthrough backend, which this test uses, it silently copies the surplus
+// frames into the earlier fragments.
+//
+// The passthrough backend copies its input verbatim, so a correctly framed
+// encode must produce one fragment of exactly frameSize bytes per frame. The
+// bug instead yields a shrinking staircase: frame 0 gets the whole buffer,
+// frame 1 all but the first frame, and so on.
+func TestMultiFrameMPEGFragmentSizes(t *testing.T) {
+	const cols, rows, frames = 8, 8, 4
+	frameSize := cols * rows // 8-bit MONOCHROME2
+
+	for _, ts := range []*transfersyntax.TransferSyntax{
+		transfersyntax.MPEG2MPML,
+		transfersyntax.MPEG4HP41,
+		transfersyntax.HEVCMP51,
+		transfersyntax.SMPTEST211020UncompressedProgressiveActiveVideo,
+	} {
+		t.Run(ts.Name, func(t *testing.T) {
+			obj := newMultiFrameObject(frames, cols, rows)
+			if err := transcoder.ChangeTransferSyntax(obj, ts); err != nil {
+				t.Fatalf("ChangeTransferSyntax(%s) with %d frames: %v", ts.Name, frames, err)
+			}
+
+			sizes := encapsulatedFragmentSizes(obj)
+			if len(sizes) != frames {
+				t.Fatalf("got %d fragments, want %d (one per frame)", len(sizes), frames)
+			}
+			for j, got := range sizes {
+				if got != frameSize {
+					t.Fatalf("fragment %d is %d bytes, want %d — the frame was sliced "+
+						"open-ended into the rest of the multi-frame buffer instead of "+
+						"bounded to its own [start,end)", j, got, frameSize)
+				}
+			}
+		})
+	}
+}

--- a/transcoder/transcoder.go
+++ b/transcoder/transcoder.go
@@ -656,16 +656,14 @@ func compress(ctx context.Context, obj media.DICOMObject, i *int, img []byte, RG
 	case transfersyntax.HEVCM10P51.UID:
 		index = beginEncapsulatedPixelData(obj, index)
 		for j = 0; j < frames; j++ {
-			offset = j * uint32(cols) * uint32(rows) * uint32(bitsa) / 8
-			if RGB {
-				offset = 3 * offset
-				if err := mpeg.MPEGencodeContext(ctx, img[offset:], cols, rows, 3, bitsa, &JPEGData, &JPEGBytes, outTS); err != nil {
-					return err
-				}
-			} else {
-				if err := mpeg.MPEGencodeContext(ctx, img[offset:], cols, rows, 1, bitsa, &JPEGData, &JPEGBytes, outTS); err != nil {
-					return err
-				}
+			// frameBounds gives this frame's [start,end). The previous code
+			// sliced img[offset:] open-ended to the end of the whole multi-frame
+			// buffer, so every frame but the last was handed too many bytes. The
+			// ffmpeg backend rejects that against an exact-size check; the
+			// passthrough backend silently copies the surplus frames in.
+			samples, start, end := frameBounds(j, cols, rows, bitsa, RGB)
+			if err := mpeg.MPEGencodeContext(ctx, img[start:end], cols, rows, samples, bitsa, &JPEGData, &JPEGBytes, outTS); err != nil {
+				return err
 			}
 			index = appendEncapsulatedFrame(obj, index, JPEGData)
 			JPEGData = nil
@@ -679,16 +677,9 @@ func compress(ctx context.Context, obj media.DICOMObject, i *int, img []byte, RG
 	case transfersyntax.SMPTEST211030PCMDigitalAudio.UID:
 		index = beginEncapsulatedPixelData(obj, index)
 		for j = 0; j < frames; j++ {
-			offset = j * uint32(cols) * uint32(rows) * uint32(bitsa) / 8
-			if RGB {
-				offset = 3 * offset
-				if err := smpte2110.SMPTE2110encodeContext(ctx, img[offset:], cols, rows, 3, bitsa, &JPEGData, &JPEGBytes, outTS); err != nil {
-					return err
-				}
-			} else {
-				if err := smpte2110.SMPTE2110encodeContext(ctx, img[offset:], cols, rows, 1, bitsa, &JPEGData, &JPEGBytes, outTS); err != nil {
-					return err
-				}
+			samples, start, end := frameBounds(j, cols, rows, bitsa, RGB)
+			if err := smpte2110.SMPTE2110encodeContext(ctx, img[start:end], cols, rows, samples, bitsa, &JPEGData, &JPEGBytes, outTS); err != nil {
+				return err
 			}
 			index = appendEncapsulatedFrame(obj, index, JPEGData)
 			JPEGData = nil


### PR DESCRIPTION
Completes the `img[offset:]` sweep across the transcoder. #54 fixed the JPEG branches; this fixes the remaining MPEG/HEVC and SMPTE 2110 ones, which I'd deferred because they sit behind the `ffmpeg`/`st2110` build tags and I couldn't exercise the native path locally.

## The problem

Both branches sliced `img[offset:]` **open-ended** to the end of the whole multi-frame buffer, so every frame but the last was handed too many bytes. Same class as #54 and the JPIP fix before it.

The consequence splits by backend:

| Backend | Behaviour |
|---|---|
| native `ffmpeg` / `st2110` | The C bridge checks `av_image_get_buffer_size(...) == src_size` exactly (`ffmpeg_bridge.c:278`). An over-long slice fails that check, so multi-frame video transcoding **errored out**. |
| pure-Go `passthrough` (default when the codecs aren't built in) | `Encode` copies its input verbatim with no size check, so it **silently** emitted the surplus frames into the earlier fragments — fragment 0 held the entire buffer. |

Unlike #54 the offset arithmetic itself was already correct here — there's no `/2` sample-vs-byte confusion — so this is purely the open-ended slice.

## The fix

Both branches now take `frameBounds`' `[start,end)` and its sample count, matching every other multi-frame encoder in the file.

## Verification

This is the part I want to be explicit about, since I flagged in #54 that I couldn't test these paths.

The **transcoder branch is pure Go**, and the passthrough backend is active in the default build — so the bug is observable without any native codec library. `TestMultiFrameMPEGFragmentSizes` transcodes a 4-frame 8-bit image to MPEG2, MPEG-4, HEVC and SMPTE 2110 and asserts the encapsulated pixel data has four fragments of exactly one frame (64 bytes) each.

- Against the previous code: fragment 0 is 256 bytes — the whole buffer — → FAIL (verified with `git stash` on `transcoder.go`).
- With the fix: one frame per fragment → PASS.

`go test ./...`, `go vet ./...`, `go test -race ./media/ ./transcoder/` green; io-scp, io-router and io-dicom-tools/go-bridge build.

**What this does NOT verify:** the native `ffmpeg`/`st2110` encode path itself — this machine has no libavcodec via pkg-config. The fix is analytically identical to #54, and the C exact-size check confirms the native path would have failed on the old slice, but the end-to-end native encode is exercised only by CI's `tagged-codec-tests` job, not locally.

## Two things noted while reading the C bridge, not fixed here

1. **`avio_buffer` leak on OOM** — in `io_ffmpeg_decode`, if `avio_alloc_context` returns NULL, the 4 KiB buffer allocated just above it is never freed (the cleanup guard is `if (avio)`, and `avio` is NULL there). OOM-only, so cosmetic, but real.
2. **Frame-per-fragment framing for MPEG.** This change makes each fragment carry one frame's worth of raw pixels, but the encapsulation still emits one fragment per frame. DICOM's MPEG/HEVC transfer syntaxes normally carry the entire elementary stream as a single fragment, so this framing may be non-conformant for third-party viewers regardless of the offset fix. That's a design question about the whole video-encode path, needs the native backend to validate, and is out of scope here — flagging for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)