### PR TITLE
fix(ffmpegbridge): free the AVIO buffer when avio_alloc_context fails

### DIFF
--- a/codecs/internal/ffmpegbridge/ffmpeg_bridge.c
+++ b/codecs/internal/ffmpegbridge/ffmpeg_bridge.c
@@ -515,6 +515,11 @@ int io_ffmpeg_decode(const uint8_t* src, size_t src_size,
 	}
 	avio = avio_alloc_context(avio_buffer, 4096, 0, &reader, io_ffmpeg_read_packet, NULL, io_ffmpeg_seek);
 	if (!avio) {
+		// Ownership of avio_buffer transfers to avio only on success; on failure
+		// it is still ours, and cleanup frees only via avio->buffer (guarded by
+		// `if (avio)`), so free it here or it leaks.
+		av_free(avio_buffer);
+		avio_buffer = NULL;
 		io_ffmpeg_set_error(err, err_len, "avio_alloc_context failed");
 		ret = AVERROR(ENOMEM);
 		goto cleanup;


### PR DESCRIPTION
The last concrete finding from the MPEG/SMPTE audit (noted in #57).

## The leak

`io_ffmpeg_decode` allocates a 4 KiB buffer and hands it to `avio_alloc_context`:

```c
avio_buffer = av_malloc(4096);
...
avio = avio_alloc_context(avio_buffer, 4096, 0, ...);
if (!avio) {
    ...
    goto cleanup;   // avio_buffer leaked here
}
```

Ownership of `avio_buffer` transfers to the `AVIOContext` only on success. The cleanup path frees it via `av_freep(&avio->buffer)` — but that is guarded by `if (avio)`, and on this path `avio` is NULL. So the buffer allocated one line earlier leaks.

## The fix

Free it in the failure branch, where ownership is still ours, and NULL it so cleanup can't touch it. `av_free` pairs with the `av_malloc` above and is already the deallocator used elsewhere in this file.

Only reachable under allocation failure, so the practical impact is small — but it is a genuine leak on an error path, and the fix is unambiguous.

## Verification

I want to be straight about this: **this host has no libavcodec via pkg-config**, and the file is behind `//go:build cgo && (ffmpeg || st2110)`, so the default toolchain here does not build it. I verified:

- the default `CGO_ENABLED=0 go build ./...` and `go vet ./...` are unaffected (the `.c` file is excluded by its build constraint);
- `av_free(uint8_t*)` is type-correct and already used at three other sites in this file.

The actual compile of the changed code is done by CI's `tagged-codec-tests` job, which builds the `ffmpeg`/`st2110` tags. I have not run the native decode path.

## Audit status

With this, every subsystem of io-dicom has been through the performance/memory and correctness/security passes. The one remaining open question — whether the MPEG/HEVC encode path should emit a single elementary-stream fragment rather than one fragment per frame (#57) — is a conformance/design decision that needs both a libavcodec host to validate and your call, so it is not something I can close from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)