### PR TITLE
perf(network): batch P-DATA fragments instead of flushing each one

### DIFF
--- a/network/p_data_tf.go
+++ b/network/p_data_tf.go
@@ -103,6 +103,13 @@ func (pd *PresentationDataTransfer) ReadDynamic(buf *media.DICOMBuffer) (err err
 	pd.PresentationContextID = pd.pdv.PresentationContextID
 	return nil
 }
+
+// Write serialises the buffered dataset into P-DATA-TF PDVs on rw. Like every
+// other *.Write(rw) method in this package it does NOT flush: the sole caller,
+// writeEncodedPDU, flushes once after Write returns. Flushing per fragment (as
+// this used to) forced one underlying write per BlockSize chunk — typically one
+// syscall per ~16 KiB of a negotiated PDU — so a multi-megabyte C-STORE cost
+// thousands of tiny writes instead of letting bufio batch them.
 func (pd *PresentationDataTransfer) Write(rw *bufio.ReadWriter) error {
 	// Reused by every writePDVHeader call below; see that function's comment.
 	var hdr [12]byte
@@ -128,7 +135,6 @@ func (pd *PresentationDataTransfer) Write(rw *bufio.ReadWriter) error {
 		if err := writePDVHeader(rw, &hdr, pd.ItemType, pd.Reserved1, pd.Length, pd.pdv.Length, pd.pdv.PresentationContextID, pd.MsgHeader); err != nil {
 			return fmt.Errorf("pdata::Write: %w", err)
 		}
-		rw.Flush()
 		pd.Length = TLength
 		return nil
 	}
@@ -165,8 +171,6 @@ func (pd *PresentationDataTransfer) Write(rw *bufio.ReadWriter) error {
 		if err != nil {
 			return fmt.Errorf("pdata::Write: %w", err)
 		}
-
-		rw.Flush()
 
 		if n != int(pd.BlockSize) {
 			return fmt.Errorf("pdata::Write: wrote %d bytes, expected %d", n, pd.BlockSize)

--- a/network/p_data_write_flush_test.go
+++ b/network/p_data_write_flush_test.go
@@ -1,0 +1,82 @@
+package network
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/media"
+)
+
+// countingWriter records how many times Write is invoked on it. Wrapped behind a
+// bufio.Writer, that count is the number of times buffered data was actually
+// drained toward the connection — i.e. the syscall count on a real socket.
+type countingWriter struct {
+	writes int
+	bytes  int
+	sink   bytes.Buffer
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	c.writes++
+	c.bytes += len(p)
+	return c.sink.Write(p)
+}
+
+// TestPDataWriteBatchesFragments pins that serialising a dataset does not force
+// one underlying write per PDV fragment.
+//
+// Pdata.Write used to call rw.Flush() after every fragment, draining the bufio
+// buffer each time, so a dataset split into N fragments cost N writes to the
+// connection. The sole caller (writeEncodedPDU) already flushes once after
+// Write returns, so those per-fragment flushes were redundant as well as slow.
+func TestPDataWriteBatchesFragments(t *testing.T) {
+	const (
+		blockSize   = 4096
+		fragments   = 32
+		payloadSize = blockSize * fragments // 128 KiB, well under the bufio buffer
+	)
+
+	buf := media.NewDICOMBuffer()
+	payload := make([]byte, payloadSize)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	if _, err := buf.Write(payload, len(payload)); err != nil {
+		t.Fatalf("seed buffer: %v", err)
+	}
+
+	pd := &PresentationDataTransfer{
+		Buffer:                buf,
+		BlockSize:             blockSize,
+		PresentationContextID: 1,
+	}
+
+	cw := &countingWriter{}
+	// A bufio buffer larger than the whole payload: with batching, everything
+	// fits and drains in a single underlying write at the final flush.
+	rw := bufio.NewReadWriter(bufio.NewReader(bytes.NewReader(nil)), bufio.NewWriterSize(cw, 256<<10))
+
+	if err := pd.Write(rw); err != nil {
+		t.Fatalf("Pdata.Write: %v", err)
+	}
+	// The caller (writeEncodedPDU) owns the flush.
+	if err := rw.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	// 32 fragments + headers, all under 256 KiB → a couple of underlying writes,
+	// not one per fragment. Pin generously below the fragment count so the test
+	// tracks intent, not bufio's exact chunking.
+	if cw.writes > 4 {
+		t.Fatalf("dataset of %d fragments caused %d underlying writes — fragments "+
+			"are not being batched (per-fragment flush regressed)", fragments, cw.writes)
+	}
+
+	// Every byte must still reach the wire: this implementation emits one PDU per
+	// PDV, so each fragment carries a full 12-byte P-DATA-TF + PDV header.
+	wantBytes := fragments * (12 + blockSize)
+	if cw.bytes != wantBytes {
+		t.Fatalf("wrote %d bytes to the wire, want %d", cw.bytes, wantBytes)
+	}
+}


### PR DESCRIPTION
First finding from a fresh full-codebase optimization pass, targeting network/IO throughput.

## The problem

`Pdata.Write` flushed the bufio writer after **every PDV fragment**:

```go
n, err := rw.Write(buff)
...
rw.Flush()   // <- every fragment
```

Each flush drains the buffer straight to the connection, so a dataset split into N fragments cost **N writes to the socket** — one per negotiated PDU block, typically ~16 KiB. A multi-megabyte C-STORE issued thousands of small writes where `bufio` was meant to batch them.

The flushes were also **redundant**: `Pdata.Write`'s only caller, `writeEncodedPDU`, already flushes once after it returns — exactly as it does for every other `*.Write(rw)` method in the package (`AssocRQ.Write`, `AppContext.Write`, …), none of which flush themselves. `Pdata.Write` was the lone exception.

## The fix

Drop both per-fragment flushes (the streaming loop and the empty-dataset PDV). Fragments accumulate in the bufio buffer and drain when it fills or at the caller's single final flush, so underlying writes now scale with the buffer size (256 KiB on the SCP by default) rather than the fragment count.

This also makes `Pdata.Write` consistent with the package's write contract: writers fill `rw`, the caller flushes.

## Verification

`TestPDataWriteBatchesFragments` wraps a counting writer behind bufio, serialises a 32-fragment (128 KiB) dataset, and asserts both the syscall count and byte-exactness:

| | underlying writes | bytes on wire |
|---|---|---|
| before (per-fragment flush) | **32** | 131 456 |
| after (batched) | **≤4** | 131 456 |

Same bytes, ~8× fewer writes here — and the ratio grows with dataset size (a 50 MB study at a 16 KiB PDU drops from ~3 200 writes to ~200 at a 256 KiB buffer).

`go test ./...`, `go vet ./...`, `go test -race ./services/` all pass, including the SCU↔SCP TCP round-trips in `services` — so the store/get/move workflows are unaffected by the change in flush timing. io-scp and io-router build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)