### PR TITLE
perf(media): slab-allocate parsed tags, drop the no-op tag pool

### DIFF
--- a/media/dicom_buffer.go
+++ b/media/dicom_buffer.go
@@ -24,6 +24,43 @@ type DICOMBuffer struct {
 	data      []byte
 	position  int
 	size      int
+
+	// tagSlab batches DICOMTag allocations for the read path. Parsed tags are
+	// retained by the DICOMObject and never freed individually, so the old
+	// sync.Pool was always empty on Get and never reclaimed anything — it added
+	// Get + zeroing overhead while still allocating one object per tag. Handing
+	// out &tagSlab[i] from a fixed-capacity chunk turns N per-tag allocations
+	// into N/tagSlabChunk. A full chunk is never grown (that would move earlier
+	// tags); a fresh chunk is allocated instead, and the old one stays alive
+	// through the tags that reference it — exactly the memory the object holds.
+	tagSlab []DICOMTag
+	tagIdx  int
+}
+
+// tagSlabChunk is the number of DICOMTags allocated per slab. A real DICOM
+// object carries dozens to hundreds of tags, so this keeps per-parse slab count
+// small while the wasted tail (unused slots in the final chunk) stays modest.
+const tagSlabChunk = 64
+
+// newTag returns the next zeroed DICOMTag from the buffer's slab.
+func (buf *DICOMBuffer) newTag() *DICOMTag {
+	if buf.tagIdx >= len(buf.tagSlab) {
+		buf.tagSlab = make([]DICOMTag, tagSlabChunk) // fresh backing array; never grow in place
+		buf.tagIdx = 0
+	}
+	t := &buf.tagSlab[buf.tagIdx]
+	buf.tagIdx++
+	return t // already zero from make
+}
+
+// releaseTag reclaims the slot for a tag that was allocated but not kept, which
+// only happens when ReadTag fails on the tag it just handed out. Since that tag
+// is always the most recent, releasing rewinds the slab index by one.
+func (buf *DICOMBuffer) releaseTag(t *DICOMTag) {
+	if buf.tagIdx > 0 && &buf.tagSlab[buf.tagIdx-1] == t {
+		buf.tagIdx--
+		*t = DICOMTag{} // clear so the slot is zero if handed out again
+	}
 }
 
 // NewDICOMBuffer creates an empty DICOMBuffer with a 4096-byte pre-allocated buffer.
@@ -143,7 +180,7 @@ func (buf *DICOMBuffer) ReadTag(explicitVR bool) (*DICOMTag, error) {
 	if err != nil {
 		return nil, err
 	}
-	tag := newTag()
+	tag := buf.newTag()
 	tag.Group = group
 	tag.Element = element
 
@@ -158,13 +195,13 @@ func (buf *DICOMBuffer) ReadTag(explicitVR bool) (*DICOMTag, error) {
 		if isLongExplicitVR(tag.VR) {
 			_, err := buf.ReadUint16(buf.bigEndian)
 			if err != nil {
-				releaseTag(tag)
+				buf.releaseTag(tag)
 				return nil, err
 			}
 
 			length, err := buf.ReadUint32(buf.bigEndian)
 			if err != nil {
-				releaseTag(tag)
+				buf.releaseTag(tag)
 				return nil, err
 			}
 
@@ -172,7 +209,7 @@ func (buf *DICOMBuffer) ReadTag(explicitVR bool) (*DICOMTag, error) {
 		} else {
 			length, err := buf.ReadUint16(buf.bigEndian)
 			if err != nil {
-				releaseTag(tag)
+				buf.releaseTag(tag)
 				return nil, err
 			}
 			tag.Length = uint32(length)
@@ -183,7 +220,7 @@ func (buf *DICOMBuffer) ReadTag(explicitVR bool) (*DICOMTag, error) {
 		}
 		length, err := buf.ReadUint32(buf.bigEndian)
 		if err != nil {
-			releaseTag(tag)
+			buf.releaseTag(tag)
 			return nil, err
 		}
 		tag.Length = length
@@ -197,7 +234,7 @@ func (buf *DICOMBuffer) ReadTag(explicitVR bool) (*DICOMTag, error) {
 		// fresh backing array is allocated rather than the old one being reused.
 		data, err := buf.ReadSlice(int(tag.Length))
 		if err != nil {
-			releaseTag(tag)
+			buf.releaseTag(tag)
 			return nil, err
 		}
 		tag.Data = data

--- a/media/dicom_tag.go
+++ b/media/dicom_tag.go
@@ -6,27 +6,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
-	"sync"
 )
-
-// tagPool recycles DICOMTag allocations in the read hot path.
-// Get returns a zeroed tag; Put resets and returns it to the pool.
-var tagPool = sync.Pool{
-	New: func() any { return &DICOMTag{} },
-}
-
-// newTag retrieves a zeroed DICOMTag from the pool.
-func newTag() *DICOMTag {
-	t := tagPool.Get().(*DICOMTag)
-	*t = DICOMTag{} // zero all fields
-	return t
-}
-
-// releaseTag returns a tag to the pool. Must not be called if the tag
-// has been added to a DICOMObject (the object owns its lifetime).
-func releaseTag(t *DICOMTag) {
-	tagPool.Put(t)
-}
 
 // DICOMTag DICOM tag structure
 type DICOMTag struct {

--- a/media/tag_slab_test.go
+++ b/media/tag_slab_test.go
@@ -1,0 +1,80 @@
+package media
+
+import "testing"
+
+// TestTagSlabCrossesChunkBoundary is the core safety property: a full slab is
+// never grown in place (that would relocate earlier tags and dangle every
+// pointer already handed out). Allocating more than one chunk's worth of tags
+// and then reading them all back must return the exact values written.
+func TestTagSlabCrossesChunkBoundary(t *testing.T) {
+	const n = tagSlabChunk*3 + 7 // spans four chunks, partially filling the last
+	buf := &DICOMBuffer{}
+	got := make([]*DICOMTag, n)
+	for i := 0; i < n; i++ {
+		tag := buf.newTag()
+		tag.Group = uint16(0x7000 + i)
+		tag.Element = uint16(i)
+		got[i] = tag
+	}
+	// Every earlier pointer must still hold its own value after later chunks
+	// were allocated — proving no in-place grow relocated them.
+	for i := 0; i < n; i++ {
+		if got[i].Group != uint16(0x7000+i) || got[i].Element != uint16(i) {
+			t.Fatalf("tag %d corrupted: got (%#04x,%#04x), want (%#04x,%#04x) — a "+
+				"slab grow must have relocated earlier tags",
+				i, got[i].Group, got[i].Element, uint16(0x7000+i), uint16(i))
+		}
+	}
+	// Distinct pointers throughout.
+	for i := 1; i < n; i++ {
+		if got[i] == got[i-1] {
+			t.Fatalf("tags %d and %d share a pointer", i-1, i)
+		}
+	}
+}
+
+// TestTagSlabReleaseReuseIsClean pins that releasing the most-recent tag rewinds
+// the slab and that the reused slot comes back zeroed — otherwise a failed read
+// would leak its stale fields into the next tag handed out.
+func TestTagSlabReleaseReuseIsClean(t *testing.T) {
+	buf := &DICOMBuffer{}
+	first := buf.newTag()
+	first.Group = 0x0010
+	first.Element = 0x0020
+	first.VR = "PN"
+	first.Length = 42
+	first.Name = "PatientName"
+	first.Data = []byte("stale")
+
+	buf.releaseTag(first)
+
+	reused := buf.newTag()
+	if reused != first {
+		t.Fatalf("release did not rewind: expected the same slot back")
+	}
+	if reused.Group != 0 || reused.Element != 0 || reused.VR != "" ||
+		reused.Length != 0 || reused.Name != "" || reused.Data != nil {
+		t.Fatalf("reused slot carried stale fields: %+v", *reused)
+	}
+}
+
+// TestTagSlabReleaseNonLatestIsNoop guards the rewind guard: releasing anything
+// other than the last-handed-out tag must not corrupt the index or reclaim a
+// live tag's slot.
+func TestTagSlabReleaseNonLatestIsNoop(t *testing.T) {
+	buf := &DICOMBuffer{}
+	a := buf.newTag()
+	a.Group = 0x1111
+	b := buf.newTag()
+	b.Group = 0x2222
+
+	buf.releaseTag(a) // not the latest — must be ignored
+
+	c := buf.newTag()
+	if c == a || c == b {
+		t.Fatalf("releasing a non-latest tag wrongly reclaimed a live slot")
+	}
+	if a.Group != 0x1111 || b.Group != 0x2222 {
+		t.Fatalf("live tags were mutated by a no-op release")
+	}
+}


### PR DESCRIPTION
Second finding from the optimization pass, targeting parse memory + speed. Backed by a profile, not a guess.

## The finding

An `-alloc_objects` profile of `NewDCMObjFromBytes` showed **96.9% of all parse allocations were `DICOMTag` structs**, coming through `sync.Pool.New`:

```
flat  flat%   sum%
96.86% 96.86%  media.init.func2        <- tagPool.New = &DICOMTag{}
```

The pool never did anything. Parsed tags are added to the `DICOMObject` and retained for its lifetime; `releaseTag` runs **only on `ReadTag` error paths**. So the pool was always empty on `Get` — every `newTag()` allocated a fresh object anyway, and on top of that paid the `Get` indirection and a redundant `*t = DICOMTag{}` zeroing on each call.

## The fix

A per-`DICOMBuffer` slab. `newTag` hands out `&tagSlab[i]` from a fixed 64-tag chunk, allocating a fresh chunk only when the current one fills. Key invariant: **a full chunk is never grown in place** — that would relocate earlier tags and dangle every pointer already handed out. Old chunks stay alive through the tags that reference them, which is exactly the memory the object already holds. N per-tag allocations become N/64.

`releaseTag` rewinds the slab index for the (always most-recent) failed tag and zeroes the slot, so a reused slot is never stale.

## Numbers (this machine)

| benchmark | before | after |
|---|---|---|
| `FromBytes/test2` | 9231 ns, 129 allocs, 18974 B | **4377 ns, 6 allocs, 18524 B** |
| `FromBytes/jpeg8` | 9547 ns, 134 allocs, 19240 B | **4631 ns, 9 allocs, 18567 B** |

**~2× faster, ~20× fewer allocations, equal-or-lower bytes/op.** The object retains the same memory; the parse just produces ~20× less GC pressure — the win compounds for a server parsing many objects. The network receive path (`ReadObj` over an accumulated P-DATA buffer) benefits identically.

## Correctness

The slab hands out pointers into shared backing arrays, so I tested the sharp edges:

- `TestTagSlabCrossesChunkBoundary` — allocates 4 chunks' worth, then verifies every earlier pointer still holds its own value (proves no in-place grow relocated them) and all pointers are distinct.
- `TestTagSlabReleaseReuseIsClean` — a released slot comes back zeroed, not carrying the failed tag's stale fields.
- `TestTagSlabReleaseNonLatestIsNoop` — releasing anything but the last tag is ignored, never reclaiming a live slot.

Full `go test ./...`, `go vet ./...`, `go test -race ./media/` pass; io-scp and io-router build.

## Note

`DICOMBuffer` is single-threaded by contract (each connection/parse owns its buffer), which the slab relies on — consistent with the existing `position`/`data` fields having no synchronisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)