### PR TITLE
perf(network): stream the dataset into P-DATA PDVs instead of buffering it first

### DIFF
--- a/media/write_obj_stream.go
+++ b/media/write_obj_stream.go
@@ -1,0 +1,41 @@
+package media
+
+import "io"
+
+// WriteObjTo streams obj's tags to w, producing byte-for-byte what
+// DICOMBuffer.WriteObj writes into a buffer — but without materialising the
+// whole serialized object first. It emits no File Meta header (unlike WriteTo),
+// so the output is a bare DIMSE stream suitable for the network P-DATA path.
+//
+// A small scratch buffer carries each tag's 8/12-byte header; the value bytes
+// are handed to w directly so a multi-megabyte pixel-data tag is never copied.
+// The scratch buffer is little-endian, matching the DICOMBuffer that WriteObj
+// runs against on the send path (network P-DATA buffers are always constructed
+// with the little-endian default and their tag values are stored pre-encoded).
+func WriteObjTo(w io.Writer, obj DICOMObject) (int64, error) {
+	scratch := &DICOMBuffer{data: make([]byte, 0, 32)}
+	explicitVR := obj.IsExplicitVR()
+	ts := obj.GetTransferSyntax()
+
+	var written int64
+	for i := 0; i < obj.TagCount(); i++ {
+		tag := obj.GetTagAt(i)
+
+		scratch.Clear()
+		writeLen := scratch.writeTagHeader(tag, explicitVR, ts)
+		if n, err := w.Write(scratch.GetData()); err != nil {
+			return written + int64(n), err
+		} else {
+			written += int64(n)
+		}
+
+		if writeLen != 0 && writeLen != 0xFFFFFFFF {
+			if n, err := w.Write(tag.Data[:writeLen]); err != nil {
+				return written + int64(n), err
+			} else {
+				written += int64(n)
+			}
+		}
+	}
+	return written, nil
+}

--- a/media/write_obj_stream_bench_test.go
+++ b/media/write_obj_stream_bench_test.go
@@ -1,0 +1,54 @@
+package media
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/dictionary/tags"
+	"github.com/innovative-io/io-dicom/dictionary/transfersyntax"
+)
+
+func benchObj(pixelBytes int) DICOMObject {
+	obj := NewEmptyDCMObj()
+	obj.SetTransferSyntax(transfersyntax.ExplicitVRLittleEndian)
+	obj.SetExplicitVR(true)
+	obj.Write(tags.SOPClassUID, "1.2.840.10008.5.1.4.1.1.7")
+	obj.Write(tags.SOPInstanceUID, "1.2.826.0.1.3680043.10.90.8")
+	obj.Write(tags.PatientName, "STREAM^BENCH")
+	pix := make([]byte, pixelBytes)
+	obj.Add(&DICOMTag{Group: 0x7FE0, Element: 0x0010, VR: "OW", Length: uint32(len(pix)), Data: pix})
+	return obj
+}
+
+// BenchmarkSendSerialize_Buffered is the old send path's serialization: WriteObj
+// grows a buffer to the whole message size (a second full copy of the pixels).
+func BenchmarkSendSerialize_Buffered(b *testing.B) {
+	for _, sz := range []int{64 << 10, 1 << 20, 4 << 20} {
+		obj := benchObj(sz)
+		b.Run(fmt.Sprintf("%dKiB", sz>>10), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				buf := NewDICOMBuffer() // fresh, as peak memory would be per send
+				buf.WriteObj(obj)
+			}
+		})
+	}
+}
+
+// BenchmarkSendSerialize_Streamed is the new path: WriteObjTo streams to the
+// wire, allocating only a small header scratch regardless of message size.
+// Writing to io.Discard isolates the serialization memory; a real send writes
+// the same payload bytes to the socket either way, so the meaningful figure
+// here is B/op, not ns/op.
+func BenchmarkSendSerialize_Streamed(b *testing.B) {
+	for _, sz := range []int{64 << 10, 1 << 20, 4 << 20} {
+		obj := benchObj(sz)
+		b.Run(fmt.Sprintf("%dKiB", sz>>10), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = WriteObjTo(io.Discard, obj)
+			}
+		})
+	}
+}

--- a/media/write_obj_stream_test.go
+++ b/media/write_obj_stream_test.go
@@ -1,0 +1,105 @@
+package media
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/dictionary/tags"
+	"github.com/innovative-io/io-dicom/dictionary/transfersyntax"
+)
+
+// buildStreamTestObj constructs an object exercising the serialization branches
+// that matter on the wire: short and long VRs, an empty-value tag, and (when
+// encapsulated) an undefined-length pixel-data tag followed by fragment items.
+func buildStreamTestObj(explicitVR bool, ts *transfersyntax.TransferSyntax, encapsulated bool) DICOMObject {
+	obj := NewEmptyDCMObj()
+	obj.SetTransferSyntax(ts)
+	obj.SetExplicitVR(explicitVR)
+
+	obj.Write(tags.SOPClassUID, "1.2.840.10008.5.1.4.1.1.7")
+	obj.Write(tags.SOPInstanceUID, "1.2.826.0.1.3680043.10.90.7")
+	obj.Write(tags.PatientName, "STREAM^EQUIV") // even length
+	obj.Write(tags.Rows, uint16(4))
+	obj.Write(tags.Columns, uint16(4))
+	obj.Write(tags.BitsAllocated, uint16(16)) // long-ish header path
+	// An empty-value tag: header only, no data bytes.
+	obj.Add(&DICOMTag{Group: 0x0008, Element: 0x0008, VR: "CS", Length: 0})
+
+	if encapsulated {
+		// Undefined-length pixel data + BOT + two fragments, the multi-fragment
+		// layout WriteObj emits as a flat run of 0xFFFE items.
+		obj.Add(&DICOMTag{Group: 0x7FE0, Element: 0x0010, VR: "OB", Length: 0xFFFFFFFF})
+		obj.Add(&DICOMTag{Group: 0xFFFE, Element: 0xE000, VR: "DL", Length: 0})
+		obj.Add(&DICOMTag{Group: 0xFFFE, Element: 0xE000, VR: "DL", Length: 6, Data: []byte{1, 2, 3, 4, 5, 6}})
+		obj.Add(&DICOMTag{Group: 0xFFFE, Element: 0xE000, VR: "DL", Length: 4, Data: []byte{7, 8, 9, 10}})
+		obj.Add(&DICOMTag{Group: 0xFFFE, Element: 0xE0DD, VR: "DL", Length: 0})
+	} else {
+		pix := make([]byte, 4*4*2)
+		for i := range pix {
+			pix[i] = byte(i)
+		}
+		obj.Add(&DICOMTag{Group: 0x7FE0, Element: 0x0010, VR: "OW", Length: uint32(len(pix)), Data: pix})
+	}
+	return obj
+}
+
+// bufferWriteObj reproduces exactly what the send path did before streaming:
+// WriteObj into a fresh little-endian DICOMBuffer, then read the bytes back.
+func bufferWriteObj(obj DICOMObject) []byte {
+	buf := NewDICOMBuffer()
+	buf.WriteObj(obj)
+	out := make([]byte, buf.GetSize())
+	copy(out, buf.GetData())
+	return out
+}
+
+// TestWriteObjToMatchesWriteObj is the correctness contract for the streaming
+// send: WriteObjTo must be byte-identical to the buffered WriteObj it replaces,
+// or the wire format silently changes.
+func TestWriteObjToMatchesWriteObj(t *testing.T) {
+	cases := []struct {
+		name         string
+		explicitVR   bool
+		ts           *transfersyntax.TransferSyntax
+		encapsulated bool
+	}{
+		{"implicit LE", false, transfersyntax.ImplicitVRLittleEndian, false},
+		{"explicit LE", true, transfersyntax.ExplicitVRLittleEndian, false},
+		{"explicit LE encapsulated", true, transfersyntax.JPEGLosslessSV1, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := buildStreamTestObj(tc.explicitVR, tc.ts, tc.encapsulated)
+			want := bufferWriteObj(obj)
+
+			var got bytes.Buffer
+			n, err := WriteObjTo(&got, obj)
+			if err != nil {
+				t.Fatalf("WriteObjTo: %v", err)
+			}
+			if int(n) != got.Len() {
+				t.Fatalf("returned count %d != bytes written %d", n, got.Len())
+			}
+			if !bytes.Equal(got.Bytes(), want) {
+				t.Fatalf("streamed bytes differ from WriteObj\n stream=%d bytes\n buffer=%d bytes\n first diff at %d",
+					got.Len(), len(want), firstDiffAt(got.Bytes(), want))
+			}
+		})
+	}
+}
+
+func firstDiffAt(a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	if len(a) != len(b) {
+		return n
+	}
+	return -1
+}

--- a/network/pdu_service.go
+++ b/network/pdu_service.go
@@ -869,11 +869,9 @@ func (pdu *pduService) writeEncodedPDU(pduType byte, writer func(rw *bufio.ReadW
 }
 
 func (pdu *pduService) Write(DCO media.DICOMObject, ItemType byte) error {
-	if pdu.Pdata.Buffer != nil {
-		pdu.Pdata.Buffer.Clear()
-	} else {
-		pdu.Pdata.Buffer = media.NewDICOMBuffer()
-	}
+	// The send path no longer touches Pdata.Buffer: WriteObjTo streams the
+	// dataset directly into PDVs below. Pdata.Buffer is now owned solely by the
+	// receive path (NextPDU), which allocates it on demand.
 
 	if pcid, ok := selectPresentationContextIDForAbstractSyntax(pdu.AcceptedPresentationContexts, negotiatedAbstractSyntaxForObject(DCO)); ok {
 		pdu.Pdata.PresentationContextID = pcid
@@ -893,17 +891,21 @@ func (pdu *pduService) Write(DCO media.DICOMObject, ItemType byte) error {
 		return errors.New("pduservice::Write - PresentationContextID==0")
 	}
 
-	if !pdu.parseDCMIntoRaw(DCO) {
-		return errors.New("pduservice::Write - ParseDCMIntoRaw failed")
-	}
-
 	pdu.Pdata.MsgHeader = ItemType
 	if pdu.AssocAC.GetMaxSubLength() > maxPduLength {
 		pdu.AssocAC.SetMaxSubLength(maxPduLength)
 	}
 
-	// Fixed MaxLength - 6 20200811
-	pdu.Pdata.BlockSize = pdu.AssocAC.GetMaxSubLength() - 6
+	// Block size = negotiated max PDU length minus the 6-byte P-DATA-TF + PDV
+	// framing overhead. A peer that negotiated 0 ("unlimited") or an implausibly
+	// large value is treated as maxPduLength, matching Connect()'s handling and
+	// avoiding an underflow on the subtraction below.
+	maxSub := pdu.AssocAC.GetMaxSubLength()
+	if maxSub == 0 || maxSub > maxPduLength {
+		maxSub = maxPduLength
+	}
+	blockSize := int(maxSub) - 6
+	pdu.Pdata.BlockSize = uint32(blockSize) // kept for readers of Pdata state
 
 	if ItemType > 0x00 {
 		sopClassUID := DCO.GetString(tags.AffectedSOPClassUID)
@@ -915,8 +917,17 @@ func (pdu *pduService) Write(DCO media.DICOMObject, ItemType byte) error {
 		}
 	}
 
+	// Stream the dataset straight into P-DATA PDVs. The old path serialised the
+	// entire object into Pdata.Buffer first (a full second copy of the pixel
+	// data) and then chunked that buffer; WriteObjTo emits the identical byte
+	// stream through pdvChunkWriter, so peak send memory is one block, not the
+	// whole message.
 	return pdu.writeEncodedPDU(byte(pdutype.PDUDataTransfer), func(rw *bufio.ReadWriter) error {
-		return pdu.Pdata.Write(rw)
+		cw := newPDVChunkWriter(rw, blockSize, pdu.Pdata.PresentationContextID, ItemType)
+		if _, err := media.WriteObjTo(cw, DCO); err != nil {
+			return err
+		}
+		return cw.Close()
 	})
 }
 
@@ -1062,11 +1073,6 @@ func (pdu *pduService) interogateAAssociateRQ(rw *bufio.ReadWriter) error {
 	return pdu.writeEncodedPDU(byte(pdutype.AssociationReject), func(rw *bufio.ReadWriter) error {
 		return pdu.AssocRJ.Write(rw)
 	})
-}
-
-func (pdu *pduService) parseDCMIntoRaw(DCO media.DICOMObject) bool {
-	pdu.Pdata.Buffer.WriteObj(DCO)
-	return true
 }
 
 func (pdu *pduService) parseRawVRIntoDCM(DCO media.DICOMObject) bool {

--- a/network/pdv_chunk_writer.go
+++ b/network/pdv_chunk_writer.go
@@ -1,0 +1,105 @@
+package network
+
+import (
+	"bufio"
+
+	"github.com/innovative-io/io-dicom/network/internal/pdutype"
+)
+
+// pdvChunkWriter is an io.Writer that splits the bytes written to it into
+// P-DATA-TF PDVs of at most blockSize payload bytes and writes them to rw. It
+// lets the DIMSE serializer (media.WriteObjTo) stream straight to the wire
+// instead of building the entire message in a buffer first.
+//
+// The last-fragment bit may only be set on the final PDV, but the writer does
+// not know which PDV is final until Close. It therefore emits a full block only
+// once it holds strictly more than one block's worth of bytes (so that block is
+// provably not the last); Close emits whatever remains — possibly empty — as the
+// terminating last-fragment PDV. For a given byte stream and blockSize this
+// produces exactly the PDV boundaries the old buffer-then-chunk path produced.
+type pdvChunkWriter struct {
+	rw        *bufio.ReadWriter
+	blockSize int
+	pcid      byte
+	baseMsg   byte // command/dataset bit: PDVCommand or PDVDataset
+	pending   []byte
+	hdr       [12]byte
+	err       error
+}
+
+func newPDVChunkWriter(rw *bufio.ReadWriter, blockSize int, pcid, baseMsg byte) *pdvChunkWriter {
+	if blockSize <= 0 {
+		blockSize = 4096
+	}
+	return &pdvChunkWriter{
+		rw:        rw,
+		blockSize: blockSize,
+		pcid:      pcid,
+		baseMsg:   baseMsg,
+		pending:   make([]byte, 0, blockSize),
+	}
+}
+
+func (w *pdvChunkWriter) Write(p []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	total := len(p)
+	for len(p) > 0 {
+		// Zero-copy fast path: staging empty and strictly more than a block
+		// available, so this block is provably not the last — emit it straight
+		// from p without copying (matters for a multi-MB pixel-data value).
+		if len(w.pending) == 0 && len(p) > w.blockSize {
+			if err := w.emit(p[:w.blockSize], false); err != nil {
+				return total - len(p), err
+			}
+			p = p[w.blockSize:]
+			continue
+		}
+		// Staging full and more bytes remain → not the last block.
+		if len(w.pending) == w.blockSize {
+			if err := w.emit(w.pending, false); err != nil {
+				return total - len(p), err
+			}
+			w.pending = w.pending[:0]
+			continue
+		}
+		take := w.blockSize - len(w.pending)
+		if take > len(p) {
+			take = len(p)
+		}
+		w.pending = append(w.pending, p[:take]...)
+		p = p[take:]
+	}
+	return total, nil
+}
+
+// Close emits the final PDV with the last-fragment bit set. It must be called
+// exactly once after the last Write. A zero-length message still emits one
+// terminating PDV so the peer unblocks from its read.
+func (w *pdvChunkWriter) Close() error {
+	if w.err != nil {
+		return w.err
+	}
+	return w.emit(w.pending, true)
+}
+
+func (w *pdvChunkWriter) emit(payload []byte, last bool) error {
+	msgHeader := w.baseMsg & PDVTypeMask
+	if last {
+		msgHeader |= PDVLastFragment
+	}
+	pdvLength := uint32(len(payload)) + 2 // + PCID + msgHeader
+	pduLength := pdvLength + 4            // + the 4-byte PDV length field
+	if err := writePDVHeader(w.rw, &w.hdr, pdutype.PDUDataTransfer, 0, pduLength, pdvLength, w.pcid, msgHeader); err != nil {
+		w.err = err
+		return err
+	}
+	if len(payload) > 0 {
+		if _, err := w.rw.Write(payload); err != nil {
+			w.err = err
+			return err
+		}
+	}
+	return nil
+}

--- a/network/pdv_chunk_writer_test.go
+++ b/network/pdv_chunk_writer_test.go
@@ -1,0 +1,126 @@
+package network
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/innovative-io/io-dicom/media"
+)
+
+// oldPathWire reproduces the pre-streaming send: the full byte stream lives in a
+// DICOMBuffer that PresentationDataTransfer.Write chunks into PDVs.
+func oldPathWire(t *testing.T, stream []byte, blockSize int, pcid, baseMsg byte) []byte {
+	t.Helper()
+	buf := media.NewDICOMBuffer()
+	if len(stream) > 0 {
+		if _, err := buf.Write(stream, len(stream)); err != nil {
+			t.Fatalf("seed buffer: %v", err)
+		}
+	}
+	pd := &PresentationDataTransfer{
+		Buffer:                buf,
+		BlockSize:             uint32(blockSize),
+		PresentationContextID: pcid,
+		MsgHeader:             baseMsg,
+	}
+	var sink bytes.Buffer
+	rw := bufio.NewReadWriter(bufio.NewReader(bytes.NewReader(nil)), bufio.NewWriter(&sink))
+	if err := pd.Write(rw); err != nil {
+		t.Fatalf("old Pdata.Write: %v", err)
+	}
+	if err := rw.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	return sink.Bytes()
+}
+
+// newPathWire runs the same stream through pdvChunkWriter, feeding it in
+// writeChunk-sized pieces to exercise accumulation across Write calls.
+func newPathWire(t *testing.T, stream []byte, blockSize, writeChunk int, pcid, baseMsg byte) []byte {
+	t.Helper()
+	var sink bytes.Buffer
+	rw := bufio.NewReadWriter(bufio.NewReader(bytes.NewReader(nil)), bufio.NewWriter(&sink))
+	cw := newPDVChunkWriter(rw, blockSize, pcid, baseMsg)
+	for off := 0; off < len(stream); off += writeChunk {
+		end := off + writeChunk
+		if end > len(stream) {
+			end = len(stream)
+		}
+		if _, err := cw.Write(stream[off:end]); err != nil {
+			t.Fatalf("chunk writer Write: %v", err)
+		}
+	}
+	if err := cw.Close(); err != nil {
+		t.Fatalf("chunk writer Close: %v", err)
+	}
+	if err := rw.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	return sink.Bytes()
+}
+
+// TestPDVChunkWriterMatchesBufferedChunking is the wire-format contract for the
+// streaming send: for any stream length and block size, the PDVs produced by
+// pdvChunkWriter must be byte-identical to those the old buffer-then-chunk path
+// produced — and independent of how the serializer split the bytes across
+// Write calls.
+func TestPDVChunkWriterMatchesBufferedChunking(t *testing.T) {
+	const (
+		blockSize = 64
+		pcid      = 3
+	)
+	// Lengths chosen around block boundaries: sub-block, exact multiples,
+	// multiples ± 1, and an empty message (which must still emit one PDV).
+	lengths := []int{0, 1, 63, 64, 65, 127, 128, 129, 200, 256, 257}
+	// Feed the new path in several granularities, including ones that never
+	// align with blockSize, to prove the boundaries come from the stream, not
+	// the Write calls.
+	writeChunks := []int{1, 7, 64, 65, 1000}
+
+	for _, baseMsg := range []byte{PDVDataset, PDVCommand} {
+		for _, n := range lengths {
+			stream := make([]byte, n)
+			for i := range stream {
+				stream[i] = byte(i*31 + 5)
+			}
+			want := oldPathWire(t, stream, blockSize, pcid, baseMsg)
+
+			for _, wc := range writeChunks {
+				got := newPathWire(t, stream, blockSize, wc, pcid, baseMsg)
+				if !bytes.Equal(got, want) {
+					t.Fatalf("len=%d baseMsg=%#x writeChunk=%d: streamed wire differs "+
+						"from buffered (got %d bytes, want %d, first diff %d)",
+						n, baseMsg, wc, len(got), len(want), firstDiffIndex(got, want))
+				}
+			}
+		}
+	}
+}
+
+// TestPDVChunkWriterDefaultsZeroBlockSize pins the blockSize<=0 guard, matching
+// the old path's `if BlockSize == 0 { BlockSize = 4096 }`.
+func TestPDVChunkWriterDefaultsZeroBlockSize(t *testing.T) {
+	if w := newPDVChunkWriter(nil, 0, 1, PDVDataset); w.blockSize != 4096 {
+		t.Fatalf("blockSize 0 -> %d, want 4096", w.blockSize)
+	}
+	if w := newPDVChunkWriter(nil, -5, 1, PDVDataset); w.blockSize != 4096 {
+		t.Fatalf("negative blockSize -> %d, want 4096", w.blockSize)
+	}
+}
+
+func firstDiffIndex(a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	if len(a) != len(b) {
+		return n
+	}
+	return -1
+}


### PR DESCRIPTION
The streaming-send optimization flagged during the audit. Cuts peak send memory from O(message) to O(one block).

## The problem

`pdu.Write` serialised the **entire** DICOM object into `pdu.Pdata.Buffer` (via `WriteObj`), then chunked that buffer into PDVs. For a C-STORE that means holding a **second full copy of the pixel data** — on top of the copy the `DICOMObject` already owns — for the duration of every send, in a buffer that persisted at the largest message size the association ever saw.

## The fix

Stream it. Two small pieces:

- **`media.WriteObjTo(w, obj)`** serialises the object's tags straight to an `io.Writer`. It emits **no File Meta header** (unlike `WriteTo`, which is for files), so it's a bare DIMSE stream — byte-for-byte what `WriteObj` produced. A multi-MB pixel-data value is handed to `w` directly, never copied through a buffer.
- **`pdvChunkWriter`** is an `io.Writer` that splits that stream into P-DATA PDVs on the wire as bytes arrive.

`pdu.Write` now does `WriteObjTo(pdvChunkWriter, DCO)` + `Close()` — no message-size buffer at all.

```
BenchmarkSendSerialize   (B/op per send)
  64 KiB object   buffered   73,728    streamed  32
  1  MiB object   buffered  1,056,768  streamed  32
  4  MiB object   buffered  4,202,506  streamed  32
```

Constant 32 B regardless of size. Since the old buffer was per-`pduService` and persisted at max message size, a server holding many associations sending large studies saves that buffer on every one.

## The one subtlety: the last-fragment bit

Only the final PDV may set the last-fragment bit, but a streamer doesn't know which PDV is final until the input ends. `pdvChunkWriter` emits a full block **only once it holds strictly more than one block** (so that block is provably not last); `Close` emits the remainder — possibly empty — as the terminating last-fragment PDV. This reproduces the **exact** PDV boundaries the old buffer-then-chunk path produced, independent of how the serializer splits its writes.

## Behaviour notes

- A peer that negotiated `MaxSubLength` 0 ("unlimited") or an implausibly large value is now treated as `maxPduLength`, matching `Connect()`'s existing handling. The old code underflowed `MaxSubLength - 6` and sent one giant PDV (which also required buffering the whole message); bounded chunking to an unlimited peer is standards-compliant and the point of streaming.
- `onRawPDU` is unchanged: `writeEncodedPDU`'s listener path still buffers the emitted PDVs and hands them over exactly as before.
- Removed the now-dead `parseDCMIntoRaw`; `Pdata.Buffer` is now owned solely by the receive path.

## Verification (byte-identical at two layers)

1. **`TestWriteObjToMatchesWriteObj`** — `WriteObjTo` == `WriteObj` across implicit LE, explicit LE, and encapsulated multi-fragment objects.
2. **`TestPDVChunkWriterMatchesBufferedChunking`** — `pdvChunkWriter`'s wire output == the old `PresentationDataTransfer.Write`'s, across lengths around every block boundary (0, ±1, exact multiples), both message types, and 5 write granularities. Neuter-checked: breaking the last-fragment bit fails it at the msgHeader byte.

Full `go test ./...`, `go vet ./...`, and `go test -race ./services/` pass — including the SCU↔SCP store/get/move socket round-trips. io-scp, io-router, io-dicom-tools/go-bridge build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)