### PR TITLE
perf(network): reuse one raw buffer for inbound P-DATA PDUs

### DIFF
--- a/network/pdu_service.go
+++ b/network/pdu_service.go
@@ -176,7 +176,21 @@ type pduService struct {
 	// allocation per inbound PDU. One association is read by a single
 	// goroutine, so sharing it across calls is safe.
 	hdrScratch [10]byte
+	// recvScratch is reused as the raw byte buffer for inbound P-DATA-TF PDUs,
+	// which dominate received traffic (a multi-megabyte C-STORE arrives as
+	// hundreds of them). Reuse is safe because a P-DATA PDU's bytes are fully
+	// consumed before the next read: emitRawPDU copies, and ReadDynamic copies
+	// each PDV payload into Pdata.Buffer. Association/release/abort PDUs are not
+	// reused here — they are rare and their parsers may retain sub-slices. Reuse
+	// is capped so a single outsized PDU cannot pin a large buffer for the life
+	// of the association.
+	recvScratch []byte
 }
+
+// recvScratchReuseMax bounds the size of P-DATA PDU whose backing buffer is
+// retained for reuse. PDUs above it get a one-off allocation, so a peer sending
+// a single huge PDU cannot inflate the per-association scratch permanently.
+const recvScratchReuseMax = 1 << 20
 
 // NewPDUService creates a PDUService. Pass PDUServiceOption values to
 // configure non-default behaviour (e.g. WithImplementationClass).
@@ -815,7 +829,20 @@ func (pdu *pduService) readIncomingPDU() (byte, []byte, error) {
 	}
 
 	remaining := int(pduLength) - 4
-	data := make([]byte, 10+remaining)
+	total := 10 + remaining
+	// P-DATA is the bulk of inbound traffic and its raw bytes are fully consumed
+	// (copied out) before the next read, so reuse one buffer for it instead of
+	// allocating per PDU. Other PDU types, and any P-DATA larger than the reuse
+	// cap, get their own buffer.
+	var data []byte
+	if itemType == pdutype.PDUDataTransfer && total <= recvScratchReuseMax {
+		if cap(pdu.recvScratch) < total {
+			pdu.recvScratch = make([]byte, total)
+		}
+		data = pdu.recvScratch[:total]
+	} else {
+		data = make([]byte, total)
+	}
 	copy(data, header[:])
 	if remaining > 0 {
 		// Re-arm: the body is a separate read, and a peer that delivered a

--- a/network/recv_buffer_reuse_bench_test.go
+++ b/network/recv_buffer_reuse_bench_test.go
@@ -1,0 +1,38 @@
+package network
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// BenchmarkReceiveMultiPDU measures allocations for receiving one DIMSE message
+// split across many P-DATA PDUs — the C-STORE receive shape. With per-PDU
+// buffer reuse the raw-buffer allocations collapse from one-per-PDU to one.
+func BenchmarkReceiveMultiPDU(b *testing.B) {
+	const (
+		pcid      = 1
+		fragments = 256
+		fragLen   = 16 << 10 // 16 KiB, a typical negotiated PDU payload
+	)
+	var wire bytes.Buffer
+	payload := make([]byte, fragLen)
+	for i := 0; i < fragments; i++ {
+		wire.Write(pdataPDU(pcid, payload, i == fragments-1))
+	}
+	raw := wire.Bytes()
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(raw)))
+	for i := 0; i < b.N; i++ {
+		pdu := NewPDUService(WithMaxMessageSize(fragments*fragLen+4096),
+			WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))).(*pduService)
+		r := bufio.NewReader(bytes.NewReader(raw))
+		w := bufio.NewWriter(&bytes.Buffer{})
+		pdu.SetConn(bufio.NewReadWriter(r, w))
+		pdu.negotiated = true
+		_, _ = pdu.NextPDU()
+	}
+}

--- a/network/recv_buffer_reuse_test.go
+++ b/network/recv_buffer_reuse_test.go
@@ -1,0 +1,80 @@
+package network
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+)
+
+// TestRecvScratchReuseAccumulatesCorrectly is the safety contract for reusing
+// one raw buffer across inbound P-DATA PDUs. Each fragment carries a distinct
+// byte pattern; if reading fragment i+1 into the reused scratch clobbered
+// fragment i before it was copied into Pdata.Buffer, the accumulated bytes would
+// be wrong or misordered.
+func TestRecvScratchReuseAccumulatesCorrectly(t *testing.T) {
+	const (
+		pcid      = 1
+		fragments = 8
+		fragLen   = 300 // > header, spans the reused buffer several times
+	)
+
+	var wire bytes.Buffer
+	var want []byte
+	for i := 0; i < fragments; i++ {
+		payload := make([]byte, fragLen)
+		for j := range payload {
+			payload[j] = byte(i*7 + j) // unique per fragment
+		}
+		want = append(want, payload...)
+		wire.Write(pdataPDU(pcid, payload, i == fragments-1))
+	}
+
+	pdu := NewPDUService().(*pduService)
+	r := bufio.NewReader(bytes.NewReader(wire.Bytes()))
+	w := bufio.NewWriter(&bytes.Buffer{})
+	pdu.SetConn(bufio.NewReadWriter(r, w))
+	pdu.negotiated = true
+
+	// The accumulated payload is not a valid DIMSE command, so NextPDU returns a
+	// parse error — but Pdata.Buffer must hold the exact concatenation first.
+	_, _ = pdu.NextPDU()
+
+	got := pdu.Pdata.Buffer.GetData()
+	if !bytes.Equal(got, want) {
+		firstDiff := 0
+		for firstDiff < len(got) && firstDiff < len(want) && got[firstDiff] == want[firstDiff] {
+			firstDiff++
+		}
+		t.Fatalf("accumulated %d bytes across %d reused-buffer reads, want %d; first "+
+			"difference at %d — buffer reuse corrupted an earlier fragment",
+			len(got), fragments, len(want), firstDiff)
+	}
+
+	// The reused scratch must actually have been used for these (sub-cap) PDUs.
+	if pdu.recvScratch == nil {
+		t.Fatal("recvScratch was never used for P-DATA PDUs")
+	}
+}
+
+// TestRecvScratchNotReusedForLargePDU pins the reuse cap: a P-DATA PDU larger
+// than recvScratchReuseMax must get its own buffer, so a single outsized PDU
+// cannot pin a large scratch for the association's lifetime.
+func TestRecvScratchNotReusedForLargePDU(t *testing.T) {
+	// One PDV whose total PDU size exceeds the reuse cap but stays under the
+	// hard 16 MiB per-PDU ceiling.
+	payload := make([]byte, recvScratchReuseMax+1024)
+	wire := pdataPDU(1, payload, true)
+
+	pdu := NewPDUService(WithMaxMessageSize(len(payload) + 4096)).(*pduService)
+	r := bufio.NewReader(bytes.NewReader(wire))
+	w := bufio.NewWriter(&bytes.Buffer{})
+	pdu.SetConn(bufio.NewReadWriter(r, w))
+	pdu.negotiated = true
+
+	_, _ = pdu.NextPDU()
+
+	if c := cap(pdu.recvScratch); c > recvScratchReuseMax {
+		t.Fatalf("an outsized PDU inflated the reusable scratch to %d bytes "+
+			"(cap is %d)", c, recvScratchReuseMax)
+	}
+}


### PR DESCRIPTION
The second receive-path candidate from the audit. Cuts per-object receive allocations by eliminating one buffer allocation per inbound PDU.

## The problem

`readIncomingPDU` allocated a fresh byte buffer for **every** inbound PDU:

```go
data := make([]byte, 10+remaining)
```

A multi-megabyte C-STORE arrives as hundreds of P-DATA PDUs, so that was hundreds of ~16 KiB transient allocations per received object.

## Why it's safe to reuse (the aliasing analysis I flagged)

P-DATA is the only PDU type received in bulk, and its raw bytes are **fully consumed before the next read**:

- `emitRawPDU` copies the slice (`append([]byte(nil), data...)`) for any raw-PDU listener, so nothing external retains it.
- `ReadDynamic` copies each PDV payload into `Pdata.Buffer`.

The returned `DICOMObject` is parsed from `Pdata.Buffer` (its own backing array), not from the raw PDU buffer, and `Pdata.Buffer` is `Reset` to a fresh array on the next `NextPDU` — so a previously returned object is never disturbed by later reuse.

Two guards keep it conservative:

- **Association/release/abort PDUs are not reused** — they are rare and their parsers may retain sub-slices, so they keep their own buffer.
- **Reuse is capped at 1 MiB** (`recvScratchReuseMax`). A P-DATA PDU above the cap gets a one-off allocation (as today), so a single outsized PDU cannot pin a large buffer for the association's lifetime. The hard per-PDU ceiling remains 16 MiB.

## Numbers — receiving a 4 MiB message as 256 PDUs

| | allocs/op | B/op | ns/op |
|---|---|---|---|
| before | 563 | 13.2 MB | 549 µs |
| after | **306** | **8.5 MB** | **419 µs** |

~46% fewer allocations (the 256 per-PDU buffers collapse to one reused buffer), ~4.7 MiB less transient garbage, ~24% faster from reduced GC pressure. Savings scale with message size. The remaining allocations are the `Pdata.Buffer` accumulation (inherent — the full message must be held to parse it) and the object parse.

## Verification

- `TestRecvScratchReuseAccumulatesCorrectly` — 8 fragments with distinct byte patterns; asserts `Pdata.Buffer` holds the exact in-order concatenation. If reading fragment i+1 into the reused buffer clobbered fragment i before it was copied out, the bytes would mismatch.
- `TestRecvScratchNotReusedForLargePDU` — a PDU above the cap does not inflate the retained scratch.

Full `go test ./...`, `go vet ./...`, `go test -race ./network/` and the SCU↔SCP round-trips in `services` pass. io-scp, io-router build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)