### PR TITLE
perf(jpeg): read entropy bits in batches, ~2.8x faster lossless decode

### DIFF
--- a/codecs/jpeg/gojpeg_lossless.go
+++ b/codecs/jpeg/gojpeg_lossless.go
@@ -142,12 +142,38 @@ func (br *bitReader) readBit() int {
 }
 
 // receive reads n bits as an unsigned integer (n may be 0).
+// receive reads n bits as an unsigned value, MSB first. It is equivalent to n
+// calls to readBit but extracts the bits in one shot from the accumulator,
+// refilling 8 at a time only as needed. readBit was ~55% of lossless decode
+// time; the per-bit call and branch dominated. n is bounded by the Huffman
+// magnitude category (<= 16), so the accumulator always has room and the fill
+// loop runs at most twice.
+//
+// The padding/realBits accounting is preserved bit-for-bit: when the entropy
+// data runs out mid-value the real bits already buffered are served and the
+// remainder is zero-padded, exactly as readBit did one bit at a time.
 func (br *bitReader) receive(n int) int {
-	v := 0
-	for i := 0; i < n; i++ {
-		v = v<<1 | br.readBit()
+	if n <= 0 {
+		return 0
 	}
-	return v
+	un := uint(n)
+	for br.nbits < un {
+		if !br.fill() {
+			got := br.nbits
+			var v uint32
+			if got > 0 {
+				v = br.bits >> (32 - got)
+				br.bits <<= got
+				br.nbits = 0
+			}
+			br.padBits += n - int(got)
+			return int(v << (un - got))
+		}
+	}
+	v := br.bits >> (32 - un)
+	br.bits <<= un
+	br.nbits -= un
+	return int(v)
 }
 
 // decodeHuff decodes one symbol using the canonical table.

--- a/codecs/jpeg/receive_batch_test.go
+++ b/codecs/jpeg/receive_batch_test.go
@@ -1,0 +1,67 @@
+package jpeg
+
+import "testing"
+
+// receiveBitByBit is the reference implementation the batched receive replaced:
+// n individual readBit calls. The batched receive must match it exactly,
+// including its padBits/realBits bookkeeping and its behaviour past end-of-data.
+func receiveBitByBit(br *bitReader, n int) int {
+	v := 0
+	for i := 0; i < n; i++ {
+		v = v<<1 | br.readBit()
+	}
+	return v
+}
+
+// TestReceiveMatchesBitByBit pins that the batched receive is bit-for-bit
+// equivalent to n readBit calls, over the same byte stream and read pattern —
+// including 0xFF byte-stuffing and reading past the end into zero padding.
+func TestReceiveMatchesBitByBit(t *testing.T) {
+	// Include a stuffed 0xFF00 (byte-stuffing) and a spread of byte values so
+	// the fill path and marker handling are exercised.
+	data := []byte{0x9C, 0xFF, 0x00, 0x3A, 0xE1, 0x00, 0x7F, 0xFF, 0x00, 0x55, 0xAA, 0x12}
+
+	// A repeating pattern of receive widths, deliberately crossing byte and
+	// accumulator boundaries, and continuing well past the data to force padding.
+	widths := []int{1, 3, 8, 5, 16, 2, 7, 11, 4, 9, 13, 6, 16, 15, 10, 8, 8, 8}
+
+	ref := &bitReader{data: data}
+	got := &bitReader{data: data}
+
+	for step, n := range widths {
+		want := receiveBitByBit(ref, n)
+		have := got.receive(n)
+		if have != want {
+			t.Fatalf("step %d receive(%d) = %d, want %d", step, n, have, want)
+		}
+		// The accounting must track identically, or truncation detection diverges.
+		if got.padBits != ref.padBits {
+			t.Fatalf("step %d padBits = %d, want %d", step, got.padBits, ref.padBits)
+		}
+		if got.realBits != ref.realBits {
+			t.Fatalf("step %d realBits = %d, want %d", step, got.realBits, ref.realBits)
+		}
+		if got.nbits != ref.nbits {
+			t.Fatalf("step %d nbits = %d, want %d", step, got.nbits, ref.nbits)
+		}
+	}
+}
+
+// TestReceiveExhaustiveWidths runs the equivalence check for every width 1..16
+// starting from a fresh reader, catching any single-width off-by-one.
+func TestReceiveExhaustiveWidths(t *testing.T) {
+	data := []byte{0xB7, 0x2D, 0xFF, 0x00, 0x8E, 0x41, 0x6A, 0xD3}
+	for n := 1; n <= 16; n++ {
+		ref := &bitReader{data: data}
+		got := &bitReader{data: data}
+		// Read several values of this width, past the end, to cover padding too.
+		for k := 0; k < 10; k++ {
+			want := receiveBitByBit(ref, n)
+			have := got.receive(n)
+			if have != want || got.padBits != ref.padBits {
+				t.Fatalf("n=%d k=%d: got (%d,pad %d), want (%d,pad %d)",
+					n, k, have, got.padBits, want, ref.padBits)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Profile-driven CPU win on a very common medical format (JPEG Lossless SOF3 — CT/MR). Output is byte-identical.

## The hot spot

A CPU profile of `BenchmarkLLDecode512` was unambiguous:

```
flat  flat%          cum   cum%
44.7% 44.7%  bitReader.readBit
21.3% 66.0%  bitReader.receive     <- calls readBit once per bit
 9.9% 86.2%  bitReader.fill
```

`receive(n)` read n bits by calling `readBit()` n times, each paying a function call plus the empty/refill branch to move a single bit.

## The fix

`receive` now extracts all n bits from the accumulator in one shot, refilling 8 bits at a time only as needed. `n` is the Huffman magnitude category (≤ 16), so the 32-bit accumulator always has room and the refill loop runs at most twice.

Nothing about the bitstream interpretation changes:
- the same bytes are consumed in the same order (0xFF byte-stuffing is still handled inside `fill`);
- the `padBits`/`realBits` truncation accounting is preserved bit-for-bit — when entropy data runs out mid-value, the buffered real bits are served and the remainder zero-padded, exactly as the per-bit loop did.

`receive` is shared with the baseline DCT decoder, so that path speeds up too.

## Numbers

```
BenchmarkLLDecode (pure-Go SOF3)
  512    67.9 MB/s -> 191.4 MB/s
  1024   67.8      -> 195.0
  2048   68.1      -> 193.0
```

**~2.8× throughput**, identical output, identical allocations (5/op).

## Verification (byte-identical)

- Existing round-trip, `TestStreamingMatchesBufferedDecode`, and truncation tests all pass unchanged — they decode real streams (including truncated ones) and compare bytes.
- New `TestReceiveMatchesBitByBit` / `TestReceiveExhaustiveWidths` pin `receive` against a bit-by-bit reference (the exact code it replaced) across widths 1..16, a stuffed `0xFF00`, and reads past end-of-data, asserting the value **and** the `padBits`/`realBits`/`nbits` state all match.

Full `go test ./...`, `go vet ./...` pass; io-scp, io-router, io-dicom-tools/go-bridge build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)