### PR TITLE
chore: ignore compiled Go test binaries (*.test)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ bench/transcode/dcmtk_transcode_bench
 
 # Local Claude Code tooling state (settings, scheduled-task locks, etc.)
 .claude/
+
+# Compiled Go test binaries (go test -c)
+*.test


### PR DESCRIPTION
`go test -c` leaves `*.test` Mach-O executables (e.g. `jpeg.test`, `jpegls.test`) as untracked files that repeatedly trip PR-hygiene checks. This adds Go's standard `*.test` convention to `.gitignore` so these regenerable artifacts are ignored.

Verified: `git check-ignore jpeg.test jpegls.test` matches both, and `git status` is clean apart from the `.gitignore` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)